### PR TITLE
chore(#2835): change deprecated k8s APIs to newer ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,12 @@ The repository includes the following charts:
 - Gravitee.io Access Management (in development)
 - Gravitee.io Alert Engine 
 
-**Note:** These charts are only compatible with Kubernetes < 1.16. For latest versions of k8s, please check that issue: https://github.com/gravitee-io/issues/issues/2835 and the associated Pull Request: https://github.com/gravitee-io/helm-charts/pull/30
-
-
 ## Charts
 
 Please look in the chart directories for the documentation for each chart. These helm charts are designed to be a lightweight way to configure our official docker images
 
 | Chart                                      | Docker documentation                                                            |
 | ------------------------------------------ | ------------------------------------------------------------------------------- |
-| [API Management](./apim/README.md)         | https://docs.gravitee.io/apim/1.x/apim_installguide_kubernetes.html                      |
+| [API Management](./apim/README.md)         | https://docs.gravitee.io/apim/1.x/apim_installguide_kubernetes.html             |
 | [Access Management](./am/README.md)        | https://docs.gravitee.io/am/2.x/am_installguide_docker.html                     |
 | [Alert Engine](./ae/README.md)             | https://docs.gravitee.io/ae/installguide_docker.html                            |

--- a/am/templates/_helpers.tpl
+++ b/am/templates/_helpers.tpl
@@ -53,3 +53,26 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s-%s" .Release.Name $name .Values.ui.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the apiVersion of deployment.
+*/}}
+{{- define "deployment.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "apps/v1" -}}
+    {{- print "apps/v1" -}}
+{{- else -}}
+    {{- print "extensions/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the apiVersion of ingress.
+*/}}
+{{- define "ingress.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+    {{- print "extensions/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+

--- a/am/templates/api/api-autoscaler.yaml
+++ b/am/templates/api/api-autoscaler.yaml
@@ -13,7 +13,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1
+    apiVersion: {{ template "deployment.apiVersion" . }}
     kind: Deployment
     name: {{ template "gravitee.api.fullname" . }}
   minReplicas: {{ .Values.api.autoscaling.minReplicas }}

--- a/am/templates/gateway/gateway-autoscaler.yaml
+++ b/am/templates/gateway/gateway-autoscaler.yaml
@@ -13,7 +13,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1
+    apiVersion: {{ template "deployment.apiVersion" . }}
     kind: {{ .Values.gateway.type }}
     name: {{ template "gravitee.gateway.fullname" . }}
   minReplicas: {{ .Values.gateway.autoscaling.minReplicas }}

--- a/am/templates/gateway/gateway-ingress.yaml
+++ b/am/templates/gateway/gateway-ingress.yaml
@@ -3,7 +3,7 @@
 {{- $serviceGWName := include "gravitee.gateway.fullname" . -}}
 {{- $serviceGWPort := .Values.gateway.service.externalPort -}}
 {{- $ingressPath   := .Values.gateway.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "gravitee.gateway.fullname" . }}

--- a/am/templates/ui/ui-autoscaler.yaml
+++ b/am/templates/ui/ui-autoscaler.yaml
@@ -13,7 +13,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1
+    apiVersion: {{ template "deployment.apiVersion" . }}
     kind: Deployment
     name: {{ template "gravitee.ui.fullname" . }}
   minReplicas: {{ .Values.ui.autoscaling.minReplicas }}

--- a/am/templates/ui/ui-ingress.yaml
+++ b/am/templates/ui/ui-ingress.yaml
@@ -3,7 +3,7 @@
 {{- $serviceAPIName := include "gravitee.ui.fullname" . -}}
 {{- $serviceAPIPort := .Values.ui.service.externalPort -}}
 {{- $ingressPath   := .Values.ui.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "gravitee.ui.fullname" . }}

--- a/apim/1.x/templates/api/api-deployment.yaml
+++ b/apim/1.x/templates/api/api-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.api.enabled -}}
-apiVersion: apps/v1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "gravitee.api.fullname" . }}

--- a/apim/1.x/templates/api/api-ingress.yaml
+++ b/apim/1.x/templates/api/api-ingress.yaml
@@ -3,7 +3,7 @@
 {{- $serviceAPIName := include "gravitee.api.fullname" . -}}
 {{- $serviceAPIPort := .Values.api.service.externalPort -}}
 {{- $ingressPath   := .Values.api.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "gravitee.api.fullname" . }}

--- a/apim/1.x/templates/gateway/gateway-deployment.yaml
+++ b/apim/1.x/templates/gateway/gateway-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.gateway.enabled -}}
-apiVersion: apps/v1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: {{ .Values.gateway.type }}
 metadata:
   name: {{ template "gravitee.gateway.fullname" . }}

--- a/apim/1.x/templates/ui/ui-deployment.yaml
+++ b/apim/1.x/templates/ui/ui-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ui.enabled -}}
-apiVersion: apps/v1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "gravitee.ui.fullname" . }}


### PR DESCRIPTION
BREAKING CHANGE: use kubernetes v1.16+