### PR TITLE
Ensure Management API and Gateway pods restart after configuration change

### DIFF
--- a/apim/Chart.yaml
+++ b/apim/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: apim
-version: 1.27.3
+version: 1.28.0
 appVersion: 1.29.5
 description: Official Gravitee.io Helm chart for API Management
 home: https://gravitee.io

--- a/apim/templates/api-deployment.yaml
+++ b/apim/templates/api-deployment.yaml
@@ -24,6 +24,9 @@ spec:
     metadata:
       annotations:
         chaos.alpha.kubernetes.io/enabled: "{{ .Values.chaos.enabled }}"
+        {{- if .Values.api.reloadOnConfigChange }}
+        checksum/config: {{ include (print $.Template.BasePath "/api-configmap.yaml") . | sha256sum }}
+        {{- end }}
       labels:
         app: {{ template "gravitee.name" . }}
         component: "{{ .Values.api.name }}"

--- a/apim/templates/gateway-deployment.yaml
+++ b/apim/templates/gateway-deployment.yaml
@@ -31,6 +31,9 @@ spec:
     metadata:
       annotations:
         chaos.alpha.kubernetes.io/enabled: "{{ .Values.chaos.enabled }}"
+        {{- if .Values.gateway.reloadOnConfigChange }}
+        checksum/config: {{ include (print $.Template.BasePath "/gateway-configmap.yaml") . | sha256sum }}
+        {{- end }}
       labels:
         app: {{ template "gravitee.name" . }}
         component: "{{ .Values.gateway.name }}"

--- a/apim/values.yaml
+++ b/apim/values.yaml
@@ -221,6 +221,7 @@ api:
   logging:
     debug: false
   restartPolicy: OnFailure
+  reloadOnConfigChange: true
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1
@@ -277,6 +278,7 @@ gateway:
   name: gateway
   logging:
     debug: false
+  reloadOnConfigChange: true
   replicaCount: 2
   # sharding_tags: 
   # tenant:


### PR DESCRIPTION
Based on https://github.com/technosophos/k8s-helm/blob/master/docs/charts_tips_and_tricks.md#automatically-roll-deployments-when-configmaps-or-secrets-change