### PR TITLE
:bug: standardization of apim deployment apiversion and support k8s 1.16

### DIFF
--- a/apim/templates/ui/ui-autoscaler.yaml
+++ b/apim/templates/ui/ui-autoscaler.yaml
@@ -13,7 +13,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: {{ template "gravitee.ui.fullname" . }}
   minReplicas: {{ .Values.ui.autoscaling.minReplicas }}

--- a/apim/templates/ui/ui-deployment.yaml
+++ b/apim/templates/ui/ui-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ui.enabled -}}
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "gravitee.ui.fullname" . }}


### PR DESCRIPTION
# What type of PR is this?

Standardization of apim deployment apiversion. 

# What this PR does / why we need it:

-  compatibility of apim management ui with kubernetes 1.16 

# Which issue(s) this PR fixes:

None