### PR TITLE
[FIX] apim: Use correct service values for mongo and elasticsearch

### DIFF
--- a/apim/values.yaml
+++ b/apim/values.yaml
@@ -126,7 +126,7 @@ mongo:
   socketKeepAlive: false
   rs: rs0
   rsEnabled: true
-  dbhost: mongo-mongodb-replicaset
+  dbhost: graviteeio-apim-mongodb-replicaset
   dbname: gravitee
   dbport: 27017
   connectTimeoutMS: 30000
@@ -193,7 +193,7 @@ es:
     #     - /path/to/key
     #     - /path/to/key2
   endpoints:
-    - http://elastic-elasticsearch-client.default.svc.cluster.local:9200
+    - http://graviteeio-apim-elasticsearch-client.default.svc.cluster.local:9200
 
 elasticsearch:
   enabled: false


### PR DESCRIPTION
When installing using helm, mongo and elasticsearch services uses the helm name in the README, which is: `graviteeio-apim`