### PR TITLE
[FIX] apim: Add nginx to configuration-snippet on ingress annotations

### DIFF
--- a/apim/values.yaml
+++ b/apim/values.yaml
@@ -363,7 +363,7 @@ api:
       - apim.example.com
     annotations:
       kubernetes.io/ingress.class: nginx
-      ingress.kubernetes.io/configuration-snippet: "etag on;\nproxy_pass_header ETag;\nproxy_set_header if-match \"\";\n"
+      nginx.ingress.kubernetes.io/configuration-snippet: "etag on;\nproxy_pass_header ETag;\nproxy_set_header if-match \"\";\n"
       # kubernetes.io/tls-acme: "true"
     #tls:
       # Secrets must be manually created in the namespace.
@@ -464,7 +464,7 @@ gateway:
       nginx.ingress.kubernetes.io/enable-rewrite-log: "true"
       kubernetes.io/app-root: /gateway
       kubernetes.io/rewrite-target: /gateway
-      # ingress.kubernetes.io/configuration-snippet: "etag on;\nproxy_pass_header ETag;\nproxy_set_header if-match \"\";\n"
+      # nginx.ingress.kubernetes.io/configuration-snippet: "etag on;\nproxy_pass_header ETag;\nproxy_set_header if-match \"\";\n"
       # kubernetes.io/tls-acme: "true"
     #tls:
       # Secrets must be manually created in the namespace.
@@ -550,7 +550,7 @@ ui:
       kubernetes.io/ingress.class: nginx
       kubernetes.io/app-root: /management
       kubernetes.io/rewrite-target: /management
-      ingress.kubernetes.io/configuration-snippet: "etag on;\nproxy_pass_header ETag;\n"
+      nginx.ingress.kubernetes.io/configuration-snippet: "etag on;\nproxy_pass_header ETag;\n"
       #tls:
       # Secrets must be manually created in the namespace.
       # - secretName: chart-example-tls


### PR DESCRIPTION
The right annotation is `nginx.ingress.kubernetes.io/configuration-snippet`