### PR TITLE
Add support for openshift routes to the helm chart this Fixes gravitee-io/issues#4062

### DIFF
--- a/apim/1.x/README.md
+++ b/apim/1.x/README.md
@@ -64,11 +64,12 @@ To configure common features such as:
 - logs database (see [elastichsearch](https://github.com/helm/charts/tree/master/stable/elasticsearch)
   chart)
 
-| Parameter              | Description        | Default |
-| ---------------------- | ------------------ | ------- |
-| `chaos.enabled`        | Enable Chaos test  | false   |
-| `inMemoryAuth.enabled` | Enable oauth login | true    |
-| `ldap.enabled`         | Enable LDAP login  | false   |
+| Parameter                 | Description        | Default |
+| ------------------------- | ------------------ | ------- |
+| `chaos.enabled`           | Enable Chaos test  | false   |
+| `inMemoryAuth.enabled`    | Enable oauth login | true    |
+| `ldap.enabled`            | Enable LDAP login  | false   |
+| `openshiftRoutes.enabled` | Use openshift-route instead of ingress | false |
 
 ### Mongo
 

--- a/apim/1.x/requirements.lock
+++ b/apim/1.x/requirements.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: elasticsearch
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.31.1
-- name: mongodb-replicaset
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 3.10.1
-digest: sha256:62d554e333f8d3fee06aa4e305490a05705486a2dad861f7a830f35f52915166
-generated: 2019-09-30T16:15:31.02545+02:00

--- a/apim/1.x/templates/api/api-ingress.yaml
+++ b/apim/1.x/templates/api/api-ingress.yaml
@@ -3,8 +3,13 @@
 {{- $serviceAPIName := include "gravitee.api.fullname" . -}}
 {{- $serviceAPIPort := .Values.api.service.externalPort -}}
 {{- $ingressPath   := .Values.api.ingress.path -}}
+{{- if .Values.openshiftRoutes.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+{{- else }}
 apiVersion: {{ template "ingress.apiVersion" . }}
 kind: Ingress
+{{- end }}
 metadata:
   name: {{ template "gravitee.api.fullname" . }}
   labels:
@@ -19,6 +24,19 @@ metadata:
       {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
+  {{- if .Values.openshiftRoutes.enabled }}
+  host: {{ .Values.api.ingress.hosts | first }}
+  path: {{ $ingressPath }}
+  port:
+    targetPort: api
+  tls:
+    termination: edge
+  to:
+    kind: Service
+    name: {{ template "gravitee.api.fullname" . }}
+    weight: 100
+  wildcardPolicy: None
+  {{- else -}}
   rules:
     {{- range $host := .Values.api.ingress.hosts }}
     - host: {{ $host }}
@@ -32,6 +50,7 @@ spec:
   {{- if .Values.api.ingress.tls }}
   tls:
 {{ toYaml .Values.api.ingress.tls | indent 4 }}
+  {{- end -}}
   {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/apim/1.x/templates/gateway/gateway-ingress.yaml
+++ b/apim/1.x/templates/gateway/gateway-ingress.yaml
@@ -3,8 +3,13 @@
 {{- $serviceGWName := include "gravitee.gateway.fullname" . -}}
 {{- $serviceGWPort := .Values.gateway.service.externalPort -}}
 {{- $ingressPath   := .Values.gateway.ingress.path -}}
+{{- if .Values.openshiftRoutes.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+{{- else }}
 apiVersion: {{ template "ingress.apiVersion" . }}
 kind: Ingress
+{{- end }}
 metadata:
   name: {{ template "gravitee.gateway.fullname" . }}
   labels:
@@ -19,6 +24,19 @@ metadata:
       {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
+  {{- if .Values.openshiftRoutes.enabled }}
+  host: {{ .Values.gateway.ingress.hosts | first }}
+  path: {{ $ingressPath }}
+  port:
+    targetPort: gateway
+  tls:
+    termination: edge
+  to:
+    kind: Service
+    name: {{ template "gravitee.gateway.fullname" . }}
+    weight: 100
+  wildcardPolicy: None
+  {{- else -}}
   rules:
     {{- range $host := .Values.gateway.ingress.hosts }}
     - host: {{ $host }}
@@ -32,6 +50,7 @@ spec:
   {{- if .Values.gateway.ingress.tls }}
   tls:
 {{ toYaml .Values.gateway.ingress.tls | indent 4 }}
+  {{- end -}}
   {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/apim/1.x/templates/ui/ui-ingress.yaml
+++ b/apim/1.x/templates/ui/ui-ingress.yaml
@@ -3,8 +3,13 @@
 {{- $serviceAPIName := include "gravitee.ui.fullname" . -}}
 {{- $serviceAPIPort := .Values.ui.service.externalPort -}}
 {{- $ingressPath   := .Values.ui.ingress.path -}}
+{{- if .Values.openshiftRoutes.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+{{- else }}
 apiVersion: {{ template "ingress.apiVersion" . }}
 kind: Ingress
+{{- end }}
 metadata:
   name: {{ template "gravitee.ui.fullname" . }}
   labels:
@@ -19,6 +24,19 @@ metadata:
       {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
+  {{- if .Values.openshiftRoutes.enabled }}
+  host: {{ .Values.ui.ingress.hosts | first }}
+  path: /
+  port:
+    targetPort: ui
+  tls:
+    termination: edge
+  to:
+    kind: Service
+    name: {{ template "gravitee.ui.fullname" . }}
+    weight: 100
+  wildcardPolicy: None
+  {{- else -}}
   rules:
     {{- range $host := .Values.ui.ingress.hosts }}
     - host: {{ $host }}
@@ -32,6 +50,7 @@ spec:
   {{- if .Values.ui.ingress.tls }}
   tls:
 {{ toYaml .Values.ui.ingress.tls | indent 4 }}
+  {{- end -}}
   {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/apim/1.x/values.yaml
+++ b/apim/1.x/values.yaml
@@ -8,6 +8,9 @@ inMemoryAuth:
   enabled: true
   allowEmailInSearchResults: false
 
+openshiftRoutes:
+  enabled: false
+
 # Default password "admin", use bcrypt ($2a$ version) to generate a new one
 adminPasswordBcrypt: $2a$10$Ihk05VSds5rUSgMdsMVi9OKMIx2yUvMz7y9VP3rJmQeizZLrhLMyq
 adminEmail:

--- a/apim/3.x/templates/gateway/gateway-ingress.yaml
+++ b/apim/3.x/templates/gateway/gateway-ingress.yaml
@@ -3,8 +3,13 @@
 {{- $serviceGWName := include "gravitee.gateway.fullname" . -}}
 {{- $serviceGWPort := .Values.gateway.service.externalPort -}}
 {{- $ingressPath   := .Values.gateway.ingress.path -}}
+{{- if .Values.openshiftRoutes.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+{{- else }}
 apiVersion: {{ template "ingress.apiVersion" . }}
 kind: Ingress
+{{- end }}
 metadata:
   name: {{ template "gravitee.gateway.fullname" . }}
   labels:
@@ -19,6 +24,19 @@ metadata:
       {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
+  {{- if .Values.openshiftRoutes.enabled }}
+  host: {{ .Values.gateway.ingress.hosts | first }}
+  path: {{ $ingressPath }}
+  port:
+    targetPort: gateway
+  tls:
+    termination: edge
+  to:
+    kind: Service
+    name: {{ template "gravitee.gateway.fullname" . }}
+    weight: 100
+  wildcardPolicy: None
+  {{- else -}}
   rules:
     {{- range $host := .Values.gateway.ingress.hosts }}
     - host: {{ $host }}
@@ -32,6 +50,7 @@ spec:
   {{- if .Values.gateway.ingress.tls }}
   tls:
 {{ toYaml .Values.gateway.ingress.tls | indent 4 }}
+  {{- end -}}
   {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/apim/3.x/templates/ui/ui-ingress.yaml
+++ b/apim/3.x/templates/ui/ui-ingress.yaml
@@ -3,8 +3,13 @@
 {{- $serviceAPIName := include "gravitee.ui.fullname" . -}}
 {{- $serviceAPIPort := .Values.ui.service.externalPort -}}
 {{- $ingressPath   := .Values.ui.ingress.path -}}
+{{- if .Values.openshiftRoutes.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+{{- else }}
 apiVersion: {{ template "ingress.apiVersion" . }}
 kind: Ingress
+{{- end }}
 metadata:
   name: {{ template "gravitee.ui.fullname" . }}
   labels:
@@ -19,6 +24,19 @@ metadata:
       {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
+  {{- if .Values.openshiftRoutes.enabled }}
+  host: {{ .Values.ui.ingress.hosts | first }}
+  path: /
+  port:
+    targetPort: ui
+  tls:
+    termination: edge
+  to:
+    kind: Service
+    name: {{ template "gravitee.ui.fullname" . }}
+    weight: 100
+  wildcardPolicy: None
+  {{- else -}}
   rules:
     {{- range $host := .Values.ui.ingress.hosts }}
     - host: {{ $host }}
@@ -32,6 +50,7 @@ spec:
   {{- if .Values.ui.ingress.tls }}
   tls:
 {{ toYaml .Values.ui.ingress.tls | indent 4 }}
+  {{- end -}}
   {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/designer/templates/api/api-ingress.yaml
+++ b/designer/templates/api/api-ingress.yaml
@@ -3,8 +3,13 @@
 {{- $serviceAPIName := include "gravitee.api.fullname" . -}}
 {{- $serviceAPIPort := .Values.api.service.externalPort -}}
 {{- $ingressPath   := .Values.api.ingress.path -}}
+{{- if .Values.openshiftRoutes.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+{{- else }}
 apiVersion: {{ template "ingress.apiVersion" . }}
 kind: Ingress
+{{- end }}
 metadata:
   name: {{ template "gravitee.api.fullname" . }}
   labels:
@@ -19,6 +24,19 @@ metadata:
       {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
+  {{- if .Values.openshiftRoutes.enabled }}
+  host: {{ .Values.api.ingress.hosts | first }}
+  path: {{ $ingressPath }}
+  port:
+    targetPort: api
+  tls:
+    termination: edge
+  to:
+    kind: Service
+    name: {{ template "gravitee.api.fullname" . }}
+    weight: 100
+  wildcardPolicy: None
+  {{- else -}}
   rules:
     {{- range $host := .Values.api.ingress.hosts }}
     - host: {{ $host }}
@@ -32,6 +50,7 @@ spec:
   {{- if .Values.api.ingress.tls }}
   tls:
 {{ toYaml .Values.api.ingress.tls | indent 4 }}
+  {{- end -}}
   {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Suggestion on how to add support for openshift routes to the helm chart. It's not completely done the labels needs to be fixed as well as some other small touch ups that have chagned since the version of the helm chart this is based on.  Please let me know if there is anything else you would like us to change as well.