### PR TITLE
bugfix(helm3_doc_issue) : fixed Helm 3 small typos in doc

### DIFF
--- a/ae/README.md
+++ b/ae/README.md
@@ -16,7 +16,7 @@ This chart will deploy the following:
   ```
 * Install it
   ```
-  $ helm install --name graviteeio-ae graviteeio/ae
+  $ helm install graviteeio-ae graviteeio/ae
   ```
 
 ## Create a chart archive
@@ -32,7 +32,7 @@ $ helm package .
 To install the chart from the Helm repository with the release name `graviteeio-ae`:
 
 ```bash
-$ helm install --name graviteeio-ae graviteeio/ae
+$ helm install graviteeio-ae graviteeio/ae
 ```
 
 To install the chart using the chart archive, run:
@@ -108,7 +108,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install --name my-release -f values.yaml gravitee
+$ helm install my-release -f values.yaml gravitee
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)

--- a/am/README.adoc
+++ b/am/README.adoc
@@ -22,7 +22,7 @@ $ helm repo add graviteeio https://helm.gravitee.io
 * Install it
 +
 ....
-$ helm install --name graviteeio-am graviteeio/am
+$ helm install graviteeio-am graviteeio/am
 
 NOTE: If you're using Helm 3, the name parameter is no more valid. Please check https://helm.sh/docs/faq/#release-names-are-now-scoped-to-the-namespace(Helm documentation)
 
@@ -43,7 +43,7 @@ To install the chart from the Helm repository with the release name
 
 [source,bash]
 ----
-$ helm install --name graviteeio-am graviteeio/am
+$ helm install graviteeio-am graviteeio/am
 ----
 
 To install the chart using the chart archive, run:

--- a/am/README.md
+++ b/am/README.md
@@ -19,7 +19,7 @@ This chart will deploy the following:
   ```
 * Install it
   ```
-  $ helm install --name graviteeio-am graviteeio/am
+  $ helm install graviteeio-am graviteeio/am
 
 **Note:** If you're using Helm 3, the name parameter is no more valid. Please check https://helm.sh/docs/faq/#release-names-are-now-scoped-to-the-namespace
 
@@ -36,7 +36,7 @@ $ helm package .
 To install the chart from the Helm repository with the release name `graviteeio-am`:
 
 ```bash
-$ helm install --name graviteeio-am graviteeio/am
+$ helm install graviteeio-am graviteeio/am
 ```
 
 To install the chart using the chart archive, run:

--- a/apim/1.x/README.adoc
+++ b/apim/1.x/README.adoc
@@ -23,7 +23,7 @@ $ helm repo add graviteeio https://helm.gravitee.io
 * Install it
 +
 ....
-$ helm install --name graviteeio-apim graviteeio/apim
+$ helm install graviteeio-apim graviteeio/apim
 ....
 
 === Create a chart archive
@@ -41,7 +41,7 @@ To install the chart from the Helm repository with the release name
 
 [source,bash]
 ----
-$ helm install --name graviteeio-apim graviteeio/apim
+$ helm install graviteeio-apim graviteeio/apim
 ----
 
 *Note:* If you're using Helm 3, the name parameter is no more valid.
@@ -742,7 +742,7 @@ can be provided while installing the chart. For example,
 
 [source,bash]
 ----
-$ helm install --name my-release -f values.yaml gravitee
+$ helm install my-release -f values.yaml gravitee
 ----
 
 ____

--- a/apim/1.x/README.md
+++ b/apim/1.x/README.md
@@ -20,7 +20,7 @@ This chart will deploy the following:
   ```
 * Install it
   ```
-  $ helm install --name graviteeio-apim graviteeio/apim
+  $ helm install graviteeio-apim graviteeio/apim
   ```
 
 ## Create a chart archive
@@ -36,7 +36,7 @@ $ helm package .
 To install the chart from the Helm repository with the release name `graviteeio-apim`:
 
 ```bash
-$ helm install --name graviteeio-apim graviteeio/apim
+$ helm install graviteeio-apim graviteeio/apim
 ```
 
 **Note:** If you're using Helm 3, the name parameter is no more valid. Please check https://helm.sh/docs/faq/#release-names-are-now-scoped-to-the-namespace
@@ -334,7 +334,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install --name my-release -f values.yaml gravitee
+$ helm install my-release -f values.yaml gravitee
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)

--- a/apim/3.x/README.adoc
+++ b/apim/3.x/README.adoc
@@ -24,7 +24,7 @@ $ helm repo add graviteeio https://helm.gravitee.io
 * Install it
 +
 ....
-$ helm install --name graviteeio-apim3x graviteeio/apim3
+$ helm install graviteeio-apim3x graviteeio/apim3
 ....
 
 === Create a chart archive
@@ -42,7 +42,7 @@ To install the chart from the Helm repository with the release name
 
 [source,bash]
 ----
-$ helm install --name graviteeio-apim3x graviteeio/apim3
+$ helm install graviteeio-apim3x graviteeio/apim3
 ----
 
 *Note:* If you're using Helm 3, the name parameter is no more valid.
@@ -743,7 +743,7 @@ can be provided while installing the chart. For example,
 
 [source,bash]
 ----
-$ helm install --name my-release -f values.yaml gravitee
+$ helm install my-release -f values.yaml gravitee
 ----
 
 ____

--- a/apim/3.x/README.md
+++ b/apim/3.x/README.md
@@ -21,7 +21,7 @@ This chart will deploy the following:
   ```
 * Install it
   ```
-  $ helm install --name graviteeio-apim3x graviteeio/apim3
+  $ helm install graviteeio-apim3x graviteeio/apim3
   ```
 
 ## Create a chart archive
@@ -37,7 +37,7 @@ $ helm package .
 To install the chart from the Helm repository with the release name `graviteeio-apim3x`:
 
 ```bash
-$ helm install --name graviteeio-apim3x graviteeio/apim3
+$ helm install graviteeio-apim3x graviteeio/apim3
 ```
 
 **Note:** If you're using Helm 3, the name parameter is no more valid. Please check https://helm.sh/docs/faq/#release-names-are-now-scoped-to-the-namespace
@@ -96,9 +96,9 @@ mongo:
   dbname: gravitee
   auth:
     enabled: false
-    username: 
+    username:
     password:
-``` 
+```
 
 If neither `mongo.uri` or `mongo.servers` are provided, you have to define the following configuration options:
 
@@ -335,7 +335,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install --name my-release -f values.yaml gravitee
+$ helm install my-release -f values.yaml gravitee
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)


### PR DESCRIPTION
* [x] replaced all [helm install --name <release_name>] occurrences with [helm install <release_name>]

* Noticed the error : 

```bash
~/a_folder$ export SET_CHART_VALUES_STRING='mongo.uri=example'
~/a_folder$ helm install --name graviteeio-apim3x graviteeio/apim3 --set "${SET_CHART_VALUES_STRING}"
Error: unknown flag: --name
```
* `helm` version : 
```bash 
~/gravitee-pr/helm$ helm version
version.BuildInfo{Version:"v3.2.0", GitCommit:"e11b7ce3b12db2941e90399e874513fbd24bcb71", GitTreeState:"clean", GoVersion:"go1.13.10"}

```