### PR TITLE
add condition for replica setting

### DIFF
--- a/ae/Chart.yaml
+++ b/ae/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ae
-version: 1.1.12
+version: 1.1.13
 appVersion: 1.2.18
 description: Official Gravitee.io Helm chart for Alert Engine
 home: https://gravitee.io

--- a/ae/templates/engine-deployment.yaml
+++ b/ae/templates/engine-deployment.yaml
@@ -22,7 +22,9 @@ spec:
     rollingUpdate:
       maxUnavailable: 1
   {{- end }}
+  {{- if not .Values.engine.autoscaling.enabled }}
   replicas: {{ .Values.engine.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "gravitee.name" . }}

--- a/am/Chart.yaml
+++ b/am/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: am
-version: 1.0.11
+version: 1.0.12
 appVersion: 3.4.0
 description: Official Gravitee.io Helm chart for Access Management
 home: https://gravitee.io

--- a/am/templates/api/api-deployment.yaml
+++ b/am/templates/api/api-deployment.yaml
@@ -11,7 +11,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 spec:
+  {{- if not .Values.api.autoscaling.enabled }}
   replicas: {{ .Values.api.replicaCount }}
+  {{- end }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/am/templates/gateway/gateway-deployment.yaml
+++ b/am/templates/gateway/gateway-deployment.yaml
@@ -22,7 +22,9 @@ spec:
     rollingUpdate:
       maxUnavailable: 1
   {{- end }}
+  {{- if not .Values.gateway.autoscaling.enabled }}
   replicas: {{ .Values.gateway.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "gravitee.name" . }}

--- a/am/templates/ui/ui-deployment.yaml
+++ b/am/templates/ui/ui-deployment.yaml
@@ -11,7 +11,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 spec:
+  {{- if not .Values.ui.autoscaling.enabled }}
   replicas: {{ .Values.ui.replicaCount }}
+  {{- end }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/apim/1.x/Chart.yaml
+++ b/apim/1.x/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: apim
-version: 1.29.13
+version: 1.29.14
 appVersion: 1.30.26
 description: Official Gravitee.io Helm chart for API Management
 home: https://gravitee.io

--- a/apim/1.x/templates/api/api-deployment.yaml
+++ b/apim/1.x/templates/api/api-deployment.yaml
@@ -11,7 +11,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 spec:
+  {{- if not .Values.api.autoscaling.enabled }}
   replicas: {{ .Values.api.replicaCount }}
+  {{- end }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/apim/1.x/templates/gateway/gateway-deployment.yaml
+++ b/apim/1.x/templates/gateway/gateway-deployment.yaml
@@ -22,7 +22,9 @@ spec:
     rollingUpdate:
       maxUnavailable: 1
   {{- end }}
+  {{- if not .Values.gateway.autoscaling.enabled }}
   replicas: {{ .Values.gateway.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "gravitee.name" . }}

--- a/apim/1.x/templates/ui/ui-deployment.yaml
+++ b/apim/1.x/templates/ui/ui-deployment.yaml
@@ -11,7 +11,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 spec:
+  {{- if not .Values.ui.autoscaling.enabled }}
   replicas: {{ .Values.ui.replicaCount }}
+  {{- end }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/apim/3.x/Chart.yaml
+++ b/apim/3.x/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: apim3
-version: 3.0.14
+version: 3.0.15
 appVersion: 3.4.0
 description: Official Gravitee.io Helm chart for API Management 3.x
 home: https://gravitee.io

--- a/apim/3.x/templates/api/api-deployment.yaml
+++ b/apim/3.x/templates/api/api-deployment.yaml
@@ -11,7 +11,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 spec:
+  {{- if not .Values.api.autoscaling.enabled }}
   replicas: {{ .Values.api.replicaCount }}
+  {{- end }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/apim/3.x/templates/gateway/gateway-deployment.yaml
+++ b/apim/3.x/templates/gateway/gateway-deployment.yaml
@@ -22,7 +22,9 @@ spec:
     rollingUpdate:
       maxUnavailable: 1
   {{- end }}
+  {{- if not .Values.gateway.autoscaling.enabled }}
   replicas: {{ .Values.gateway.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "gravitee.name" . }}

--- a/apim/3.x/templates/portal/portal-deployment.yaml
+++ b/apim/3.x/templates/portal/portal-deployment.yaml
@@ -11,7 +11,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 spec:
+  {{- if not .Values.portal.autoscaling.enabled }}
   replicas: {{ .Values.portal.replicaCount }}
+  {{- end }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/apim/3.x/templates/ui/ui-deployment.yaml
+++ b/apim/3.x/templates/ui/ui-deployment.yaml
@@ -11,7 +11,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 spec:
+  {{- if not .Values.ui.autoscaling.enabled }}
   replicas: {{ .Values.ui.replicaCount }}
+  {{- end }}
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
Helm3 replaces the replica count set by the HPA repeatedly, resulting in a up- and down-scaling loop.

Because of that it is necessary to update the helm charts.