### PR TITLE
[#2820] add company name to configmap template

### DIFF
--- a/apim/3.x/templates/ui/ui-configmap.yaml
+++ b/apim/3.x/templates/ui/ui-configmap.yaml
@@ -26,6 +26,11 @@ data:
         "title": "{{ .Values.ui.managementTitle }}"
       }
       {{- end }}
+      {{- if .Values.ui.companyName }},
+      "company": {
+        "name": "{{ .Values.ui.companyName }}"
+      }
+      {{- end }}
       {{- if .Values.ui.documentationLink }},
       "documentation": {
         "url": "{{ .Values.ui.documentationLink }}"

--- a/apim/3.x/values.yaml
+++ b/apim/3.x/values.yaml
@@ -716,6 +716,7 @@ portal:
 ui:
   enabled: true
   name: ui
+  companyName: Gravitee.io
   title: Management UI
   managementTitle: API Management
   documentationLink: http://docs.gravitee.io/


### PR DESCRIPTION
In relation to https://github.com/gravitee-io/issues/issues/2820. Be able to specify company name from `values.yaml`. 