### PR TITLE
Fix requirements - Update Helm Chart Repository

### DIFF
--- a/am/requirements.yaml
+++ b/am/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mongodb-replicaset
   version: ^3.10.1
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable
   condition: mongodb-replicaset.enabled

--- a/designer/requirements.yaml
+++ b/designer/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mongodb-replicaset
   version: ^3.10.1
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable
   condition: mongodb-replicaset.enabled


### PR DESCRIPTION
Since November 13, 2020, the new location for the stable repository is https://charts.helm.sh/stable and the new location for the incubator repository is https://charts.helm.sh/incubator.

It was change on apim, but not in am and designer.

J.L.