### PR TITLE
Mtls socket nginx annotation on ingress

### DIFF
--- a/cockpit/templates/api/api-ingress.yaml
+++ b/cockpit/templates/api/api-ingress.yaml
@@ -15,6 +15,8 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   annotations:
+    # the ssl passthrough annotation is required for MTLS communication between Gravitee Cockpit and Gravitee APIM / Gravitee AM
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     {{- range $key, $value := .Values.api.ingress.annotations }}
       {{ $key }}: {{ $value | quote }}
     {{- end }}


### PR DESCRIPTION
see https://github.com/gravitee-io/gravitee-cockpit/issues/142 : 

I think what here makes sense, is that we add this annotation directly into the source code of the Helm Chart : that's about MLTS and cockpit connecting with APIM and AM, even in the source code of Cockpit, this is not an option, this is a core feature of Cockpit. @brasseld agreee ?