### PR TITLE
Issue/#2820 add technical api options to configmap template

### DIFF
--- a/apim/3.x/templates/api/api-configmap.yaml
+++ b/apim/3.x/templates/api/api-configmap.yaml
@@ -70,7 +70,7 @@ data:
     services:
       core:
         http:
-          enabled: {{ .Values.api.http.services.core.http.enabled | default false }}
+          enabled: {{ .Values.api.http.services.core.http.enabled | default true }}
           port: {{ .Values.api.http.services.core.http.port | default "18083" }}
           host: {{ .Values.api.http.services.core.http.host | default "localhost" }}
           authentication:

--- a/apim/3.x/templates/api/api-configmap.yaml
+++ b/apim/3.x/templates/api/api-configmap.yaml
@@ -66,15 +66,15 @@ data:
         {{- end }}
       {{- end }}
 
-      
+
     services:
       core:
-        http: 
-          enabled: true
-          port: {{ .Values.api.http.services.core.http.port |default "18083" }}
-          host: {{ .Values.api.http.services.core.http.host |default "localhost" }}
+        http:
+          enabled: {{ .Values.api.http.services.core.http.enabled | default false }}
+          port: {{ .Values.api.http.services.core.http.port | default "18083" }}
+          host: {{ .Values.api.http.services.core.http.host | default "localhost" }}
           authentication:
-            type: basic
+            type: {{ .Values.api.http.services.core.http.authentication.type | default "basic" }}
             users:
               admin: {{ .Values.api.http.services.core.http.authentication.password }}
     {{- if and .Values.api.http .Values.api.http.client }}

--- a/apim/3.x/templates/api/api-configmap.yaml
+++ b/apim/3.x/templates/api/api-configmap.yaml
@@ -76,7 +76,7 @@ data:
           authentication:
             type: {{ .Values.api.http.services.core.http.authentication.type | default "basic" }}
             users:
-              admin: {{ .Values.api.http.services.core.http.authentication.password }}
+              admin: {{ .Values.api.http.services.core.http.authentication.password | default "adminadmin"}}
     {{- if and .Values.api.http .Values.api.http.client }}
     httpClient:
       {{- if .Values.api.http.client.timeout }}

--- a/apim/3.x/templates/gateway/gateway-configmap.yaml
+++ b/apim/3.x/templates/gateway/gateway-configmap.yaml
@@ -145,7 +145,7 @@ data:
     services:
       core:
         http:
-          enabled: {{ .Values.gateway.services.core.http.enabled | default false }}
+          enabled: {{ .Values.gateway.services.core.http.enabled | default true }}
           port: {{ .Values.gateway.services.core.http.port | default "18082" }}
           host: {{ .Values.gateway.services.core.http.host | default "localhost" }}
           authentication:

--- a/apim/3.x/templates/gateway/gateway-configmap.yaml
+++ b/apim/3.x/templates/gateway/gateway-configmap.yaml
@@ -145,16 +145,13 @@ data:
     services:
       core:
         http:
-          port: 18082
-          host: localhost
+          enabled: {{ .Values.gateway.services.core.http.enabled | default false }}
+          port: {{ .Values.gateway.services.core.http.port | default "18082" }}
+          host: {{ .Values.gateway.services.core.http.host | default "localhost" }}
           authentication:
-            # authentication type to be used for the core services
-            # - none : to disable authentication
-            # - basic : to use basic authentication
-            # default is "basic"
-            type: basic
+            type: {{ .Values.gateway.services.core.http.authentication.type | default "basic" }}
             users:
-              admin: adminadmin
+              admin: {{ .Values.gateway.services.core.http.authentication.password | default "adminadmin" }}
       # Synchronization daemon used to keep the gateway state in sync with the configuration from the management repository
       # Be aware that, by disabling it, the gateway will not be sync with the configuration done through management API
       # and management UI

--- a/apim/3.x/templates/gateway/gateway-service.yaml
+++ b/apim/3.x/templates/gateway/gateway-service.yaml
@@ -27,6 +27,12 @@ spec:
       protocol: TCP
       name: {{ .Values.gateway.name }}-bridge
     {{- end }}
+    {{- if .Values.gateway.services.core.service.enabled }}
+    - port: {{ .Values.gateway.services.core.service.externalPort }}
+      targetPort: {{ .Values.gateway.services.core.http.port }}
+      protocol: TCP
+      name: {{ .Values.gateway.name }}-technical
+    {{- end }}
   selector:
     app.kubernetes.io/name: {{ template "gravitee.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/apim/3.x/templates/gateway/gateway-technical-ingress.yaml
+++ b/apim/3.x/templates/gateway/gateway-technical-ingress.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.gateway.services.core.http.enabled -}}
+{{- if .Values.gateway.services.core.ingress.enabled -}}
+{{- $serviceAPIName := include "gravitee.gateway.fullname" . -}}
+{{- $serviceAPIPort := .Values.gateway.services.core.service.externalPort -}}
+{{- $ingressPath   := .Values.gateway.services.core.ingress.path -}}
+apiVersion: {{ template "ingress.apiVersion" . }}
+kind: Ingress
+metadata:
+  name: {{ template "gravitee.gateway.fullname" . }}-technical
+  labels:
+    app.kubernetes.io/app: {{ template "gravitee.name" . }}
+    app.kubernetes.io/component: "{{ .Values.gateway.name }}"
+    app.kubernetes.io/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/release: {{ .Release.Name }}
+    app.kubernetes.io/heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.gateway.services.core.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.gateway.services.core.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $serviceAPIName }}
+              servicePort: {{ $serviceAPIPort }}
+    {{- end -}}
+  {{- if .Values.gateway.services.core.ingress.tls }}
+  tls:
+{{ toYaml .Values.gateway.services.core.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/apim/3.x/values.yaml
+++ b/apim/3.x/values.yaml
@@ -546,6 +546,28 @@ gateway:
       # username: 
       # pssword: 
   services:
+    core:
+      http:
+        enabled: true
+        port: 18082
+        host: localhost
+        authentication:
+          type: basic
+          password: adminadmin
+      ingress:
+        enabled: false
+#          path: /management/_(.*)
+#          hosts:
+#            - apim.example.com
+#          annotations:
+#            kubernetes.io/ingress.class: nginx
+#            nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      service: 
+#       If you choose to enable this service, you'll need to expose the technical api
+#       on an accessible host outside of the pod: api.http.services.core.http.host
+        enabled: false
+#         type: ClusterIP
+#         externalPort: 18082
     bridge:
       enabled: false
       # version: 3.3.1

--- a/apim/3.x/values.yaml
+++ b/apim/3.x/values.yaml
@@ -381,10 +381,11 @@ api:
     services:
       core:
         http:
+          enabled: true
           port: 18083
           host: localhost
           authentication:
-            password: adminadmin  
+            password: adminadmin
         ingress:
           enabled: false
 #          path: /management/_(.*)


### PR DESCRIPTION
The current helm chart templates hard codes the spec of the gateway technical api. This PR fixes that.
1. Added new gateway technical ingress template
2. Adjusted gateway service template to include technical service
3. Adjusted gateway configmap template to use `values.yaml` instead of hard coding
4. Adjust default `values.yaml` to provide some sane defaults for these new values.

Other small changes relating to technical api for the api component:
1. Adjust api configmap template to be able to specify technical api enable flag and auth method

In relation to https://github.com/gravitee-io/issues/issues/2820