### PR TITLE
[#2820] add mongo authSource field to configmaps when not using Mongo URI

### DIFF
--- a/apim/3.x/templates/api/api-configmap.yaml
+++ b/apim/3.x/templates/api/api-configmap.yaml
@@ -51,6 +51,7 @@ data:
         {{- if (eq .Values.mongo.auth.enabled true) }}
         username: {{ .Values.mongo.auth.username }}
         password: {{ .Values.mongo.auth.password }}
+        authSource: {{ .Values.mongo.auth.source | default "gravitee" }}
         {{- end }}
         {{- else }}
         uri: mongodb://{{- if (eq .Values.mongo.auth.enabled true) }}{{ .Values.mongo.auth.username }}:{{ .Values.mongo.auth.password }}@{{- end }}{{ .Values.mongo.dbhost }}:{{ .Values.mongo.dbport }}/{{ .Values.mongo.dbname }}?{{- if .Values.mongo.rsEnabled }}&replicaSet={{ .Values.mongo.rs }}{{- end }}{{- if (eq .Values.mongo.auth.enabled true) }}&authSource={{ .Values.mongo.auth.source }}{{- end }}{{- if .Values.mongo.connectTimeoutMS }}&connectTimeoutMS={{ .Values.mongo.connectTimeoutMS }}{{- end }}

--- a/apim/3.x/templates/gateway/gateway-configmap.yaml
+++ b/apim/3.x/templates/gateway/gateway-configmap.yaml
@@ -57,6 +57,7 @@ data:
         {{- if (eq .Values.mongo.auth.enabled true) }}
         username: {{ .Values.mongo.auth.username }}
         password: {{ .Values.mongo.auth.password }}
+        authSource: {{ .Values.mongo.auth.source | default "gravitee" }}
         {{- end }}
         {{- else }}
         uri: mongodb://{{- if (eq .Values.mongo.auth.enabled true) }}{{ .Values.mongo.auth.username }}:{{ .Values.mongo.auth.password }}@{{- end }}{{ .Values.mongo.dbhost }}:{{ .Values.mongo.dbport }}/{{ .Values.mongo.dbname }}?{{- if .Values.mongo.rsEnabled }}&replicaSet={{ .Values.mongo.rs }}{{- end }}{{- if (eq .Values.mongo.auth.enabled true) }}&authSource={{ .Values.mongo.auth.source }}{{- end }}{{- if .Values.mongo.connectTimeoutMS }}&connectTimeoutMS={{ .Values.mongo.connectTimeoutMS }}{{- end }}


### PR DESCRIPTION
`.Values.mongo.auth.source` is only used if mongo uri is used. This PR allows to set the `authSource` in the resulting `gravitee.yml` with this value if mongo uri is not used.

Related to gravitee-io/issues#2820.

