### PR TITLE
[#2820] add authSource field to ratelimit section

### DIFF
--- a/apim/3.x/templates/gateway/gateway-configmap.yaml
+++ b/apim/3.x/templates/gateway/gateway-configmap.yaml
@@ -98,6 +98,7 @@ data:
         {{- if (eq .Values.mongo.auth.enabled true) }}
         username: {{ .Values.mongo.auth.username }}
         password: {{ .Values.mongo.auth.password }}
+        authSource: {{ .Values.mongo.auth.source | default "gravitee" }}
         {{- end }}
         {{- else }}
         uri: mongodb://{{- if (eq .Values.mongo.auth.enabled true) }}{{ .Values.mongo.auth.username }}:{{ .Values.mongo.auth.password }}@{{- end }}{{ .Values.mongo.dbhost }}:{{ .Values.mongo.dbport }}/{{ .Values.mongo.dbname }}?{{- if .Values.mongo.rsEnabled }}&replicaSet={{ .Values.mongo.rs }}{{- end }}{{- if (eq .Values.mongo.auth.enabled true) }}&authSource={{ .Values.mongo.auth.source }}{{- end }}{{- if .Values.mongo.connectTimeoutMS }}&connectTimeoutMS={{ .Values.mongo.connectTimeoutMS }}{{- end }}


### PR DESCRIPTION
Previous PR concerning this problem forgot to include the `authSource` option inside the `ratelimit` section of the `gateway-configmap` template.

See https://github.com/gravitee-io/helm-charts/pull/87#issuecomment-775137087.

Related to gravitee-io/issues#2820.