### PR TITLE
Add support for Hazelcast cache

### DIFF
--- a/apim/3.x/templates/gateway/gateway-configmap.yaml
+++ b/apim/3.x/templates/gateway/gateway-configmap.yaml
@@ -142,7 +142,7 @@ data:
         {{- end }}
       {{- end }}
     cache:
-      type: ehcache
+      type: {{ .Values.cache.type | default "ehcache" }}
       enabled: true
 
     # Sharding tags configuration
@@ -386,4 +386,47 @@ data:
 
     </configuration>
   {{- end -}}
+        
+  {{- if (eq .Values.cache.type "hazelcast") }}
+  hazelcast.xml: |
+    <?xml version="1.0" encoding="UTF-8"?>
+
+    <hazelcast xmlns="http://www.hazelcast.com/schema/config"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://www.hazelcast.com/schema/config       
+              http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+
+        <network>
+            <join>
+                <!-- Multicast is disabled by default to avoid latency when starting gateway -->
+                <multicast enabled="false" />
+            </join>
+        </network>
+
+        <map name="apikeys">
+            <!-- Eviction is managed programmatically-->
+            <eviction eviction-policy="NONE" size="0"></eviction>
+        </map>
+
+        <map name="subscriptions">
+            <!-- Eviction is managed programmatically-->
+            <eviction eviction-policy="NONE" size="0"></eviction>
+        </map>
+
+        <queue name="heartbeats">
+            <!-- By default, gateway emits one event every 5 seconds-->
+            <!-- Keep 1 hour of events -->
+            <max-size>720</max-size>
+        </queue>
+
+        <map name="apis">
+            <!-- Eviction is managed programmatically-->
+            <eviction eviction-policy="NONE" size="0"></eviction>
+        </map>
+
+        {{ .Values.cache.config | indent 8 }}
+
+    </hazelcast>
+  {{- end -}}
+
   {{- end -}}

--- a/apim/3.x/templates/gateway/gateway-configmap.yaml
+++ b/apim/3.x/templates/gateway/gateway-configmap.yaml
@@ -398,8 +398,12 @@ data:
 
         <network>
             <join>
-                <!-- Multicast is disabled by default to avoid latency when starting gateway -->
-                <multicast enabled="false" />
+                <multicast enabled="false"/>
+                <tcp-ip enabled="false"/>
+                <kubernetes enabled="true">
+                    <namespace>{{ .Release.Namespace }}</namespace>
+                    <service-name>{{ template "gravitee.gateway.fullname" . }}</service-name>
+                </kubernetes>
             </join>
         </network>
 

--- a/apim/3.x/templates/gateway/gateway-deployment.yaml
+++ b/apim/3.x/templates/gateway/gateway-deployment.yaml
@@ -154,6 +154,11 @@ spec:
               mountPath: /opt/graviteeio-gateway/config/logback.xml
               subPath: logback.xml
           {{- end }}
+          {{- if (eq .Values.cache.type "hazelcast") }}
+            - name: config
+              mountPath: /opt/graviteeio-gateway/config/hazelcast.xml
+              subPath: hazelcast.xml
+          {{- end }}
           {{- if and .Values.jdbc.driver (eq .Values.management.type "jdbc") }}
             - name: graviteeio-apim-repository-jdbc-ext
               mountPath: /opt/graviteeio-gateway/plugins/ext/repository-jdbc

--- a/apim/3.x/values.yaml
+++ b/apim/3.x/values.yaml
@@ -334,6 +334,9 @@ management:
 ratelimit:
   type: mongodb
 
+cache:
+  type: ehcache
+
 api:
   enabled: true
   name: api


### PR DESCRIPTION
Add support for new Hazelcast cache in Gravitee APIM 3.7
See
- https://www.gravitee.io/article/gravitee-io-api-platform-3-7
- https://github.com/gravitee-io/issues/issues/599

ehcache remains the default.

hazelcast.xml will be built based on default file I gathered from Gravitee APIM + `<network>` section is inspired from Gravitee Alert Engine + custom `<map>` blocks are possible using Values.cache.config
NB: I never used Hazelcache myself, if someone have knowledge, feel free to review my implementation 😊 Or other solution is to make hazelcast.xml totally customizable 🤔