### PR TITLE
Aligne am-management and am-gateway mongodb configuration

### DIFF
--- a/am/templates/api/api-configmap.yaml
+++ b/am/templates/api/api-configmap.yaml
@@ -50,6 +50,9 @@ data:
         {{- if .Values.mongo.auth.password }}
         password: {{ .Values.mongo.auth.password }}
         {{- end }}
+        {{- if .Values.mongo.auth.source }}
+        authSource: {{ .Values.mongo.auth.source }}
+        {{- end }}
         {{- end }}
         {{- else }}
         uri: mongodb://{{- if (eq .Values.mongo.auth.enabled true) }}{{ .Values.mongo.auth.username }}:{{ .Values.mongo.auth.password }}@{{- end }}{{ .Values.mongo.dbhost }}:{{ .Values.mongo.dbport }}/{{ .Values.mongo.dbname }}?{{- if .Values.mongo.rsEnabled }}&replicaSet={{ .Values.mongo.rs }}{{- end }}{{- if (eq .Values.mongo.auth.enabled true) }}&authSource={{ .Values.mongo.auth.source }}{{- end }}{{- if .Values.mongo.connectTimeoutMS }}&connectTimeoutMS={{ .Values.mongo.connectTimeoutMS }}{{- end }}
@@ -84,6 +87,9 @@ data:
         username: {{ .Values.mongo.auth.username }}
         {{- if .Values.mongo.auth.password }}
         password: {{ .Values.mongo.auth.password }}
+        {{- end }}
+        {{- if .Values.mongo.auth.source }}
+        authSource: {{ .Values.mongo.auth.source }}
         {{- end }}
         {{- end }}
         {{- else }}

--- a/am/templates/api/api-configmap.yaml
+++ b/am/templates/api/api-configmap.yaml
@@ -47,7 +47,9 @@ data:
         dbname: {{ .Values.mongo.dbname }}
         {{- if (eq .Values.mongo.auth.enabled true) }}
         username: {{ .Values.mongo.auth.username }}
+        {{- if .Values.mongo.auth.password }}
         password: {{ .Values.mongo.auth.password }}
+        {{- end }}
         {{- end }}
         {{- else }}
         uri: mongodb://{{- if (eq .Values.mongo.auth.enabled true) }}{{ .Values.mongo.auth.username }}:{{ .Values.mongo.auth.password }}@{{- end }}{{ .Values.mongo.dbhost }}:{{ .Values.mongo.dbport }}/{{ .Values.mongo.dbname }}?{{- if .Values.mongo.rsEnabled }}&replicaSet={{ .Values.mongo.rs }}{{- end }}{{- if (eq .Values.mongo.auth.enabled true) }}&authSource={{ .Values.mongo.auth.source }}{{- end }}{{- if .Values.mongo.connectTimeoutMS }}&connectTimeoutMS={{ .Values.mongo.connectTimeoutMS }}{{- end }}
@@ -80,7 +82,9 @@ data:
         dbname: {{ .Values.mongo.dbname }}
         {{- if (eq .Values.mongo.auth.enabled true) }}
         username: {{ .Values.mongo.auth.username }}
+        {{- if .Values.mongo.auth.password }}
         password: {{ .Values.mongo.auth.password }}
+        {{- end }}
         {{- end }}
         {{- else }}
         uri: mongodb://{{- if (eq .Values.mongo.auth.enabled true) }}{{ .Values.mongo.auth.username }}:{{ .Values.mongo.auth.password }}@{{- end }}{{ .Values.mongo.dbhost }}:{{ .Values.mongo.dbport }}/{{ .Values.mongo.dbname }}?{{- if .Values.mongo.rsEnabled }}&replicaSet={{ .Values.mongo.rs }}{{- end }}{{- if (eq .Values.mongo.auth.enabled true) }}&authSource={{ .Values.mongo.auth.source }}{{- end }}{{- if .Values.mongo.connectTimeoutMS }}&connectTimeoutMS={{ .Values.mongo.connectTimeoutMS }}{{- end }}

--- a/am/templates/gateway/gateway-configmap.yaml
+++ b/am/templates/gateway/gateway-configmap.yaml
@@ -56,7 +56,9 @@ data:
         dbname: {{ .Values.mongo.dbname }}
         {{- if (eq .Values.mongo.auth.enabled true) }}
         username: {{ .Values.mongo.auth.username }}
+        {{- if .Values.mongo.auth.password }}
         password: {{ .Values.mongo.auth.password }}
+        {{- end }}
         {{- end }}
         {{- else }}
         uri: mongodb://{{- if (eq .Values.mongo.auth.enabled true) }}{{ .Values.mongo.auth.username }}:{{ .Values.mongo.auth.password }}@{{- end }}{{ .Values.mongo.dbhost }}:{{ .Values.mongo.dbport }}/{{ .Values.mongo.dbname }}?{{- if .Values.mongo.rsEnabled }}&replicaSet={{ .Values.mongo.rs }}{{- end }}{{- if (eq .Values.mongo.auth.enabled true) }}&authSource={{ .Values.mongo.auth.source }}{{- end }}{{- if .Values.mongo.connectTimeoutMS }}&connectTimeoutMS={{ .Values.mongo.connectTimeoutMS }}{{- end }}
@@ -89,7 +91,9 @@ data:
         dbname: {{ .Values.mongo.dbname }}
         {{- if (eq .Values.mongo.auth.enabled true) }}
         username: {{ .Values.mongo.auth.username }}
+        {{- if .Values.mongo.auth.password }}
         password: {{ .Values.mongo.auth.password }}
+        {{- end }}
         {{- end }}
         {{- else }}
         uri: mongodb://{{- if (eq .Values.mongo.auth.enabled true) }}{{ .Values.mongo.auth.username }}:{{ .Values.mongo.auth.password }}@{{- end }}{{ .Values.mongo.dbhost }}:{{ .Values.mongo.dbport }}/{{ .Values.mongo.dbname }}?{{- if .Values.mongo.rsEnabled }}&replicaSet={{ .Values.mongo.rs }}{{- end }}{{- if (eq .Values.mongo.auth.enabled true) }}&authSource={{ .Values.mongo.auth.source }}{{- end }}{{- if .Values.mongo.connectTimeoutMS }}&connectTimeoutMS={{ .Values.mongo.connectTimeoutMS }}{{- end }}

--- a/am/templates/gateway/gateway-configmap.yaml
+++ b/am/templates/gateway/gateway-configmap.yaml
@@ -59,6 +59,9 @@ data:
         {{- if .Values.mongo.auth.password }}
         password: {{ .Values.mongo.auth.password }}
         {{- end }}
+        {{- if .Values.mongo.auth.source }}
+        authSource: {{ .Values.mongo.auth.source }}
+        {{- end }}
         {{- end }}
         {{- else }}
         uri: mongodb://{{- if (eq .Values.mongo.auth.enabled true) }}{{ .Values.mongo.auth.username }}:{{ .Values.mongo.auth.password }}@{{- end }}{{ .Values.mongo.dbhost }}:{{ .Values.mongo.dbport }}/{{ .Values.mongo.dbname }}?{{- if .Values.mongo.rsEnabled }}&replicaSet={{ .Values.mongo.rs }}{{- end }}{{- if (eq .Values.mongo.auth.enabled true) }}&authSource={{ .Values.mongo.auth.source }}{{- end }}{{- if .Values.mongo.connectTimeoutMS }}&connectTimeoutMS={{ .Values.mongo.connectTimeoutMS }}{{- end }}
@@ -93,6 +96,9 @@ data:
         username: {{ .Values.mongo.auth.username }}
         {{- if .Values.mongo.auth.password }}
         password: {{ .Values.mongo.auth.password }}
+        {{- end }}
+        {{- if .Values.mongo.auth.source }}
+        authSource: {{ .Values.mongo.auth.source }}
         {{- end }}
         {{- end }}
         {{- else }}

--- a/am/templates/gateway/gateway-configmap.yaml
+++ b/am/templates/gateway/gateway-configmap.yaml
@@ -46,9 +46,19 @@ data:
       type: {{ .Values.management.type | default "mongodb" }}
       {{- if or (eq .Values.management.type "mongodb") (kindIs "invalid" .Values.management.type) }}
       mongodb:
+        sslEnabled: {{ .Values.mongo.sslEnabled }}
+        socketKeepAlive: {{ .Values.mongo.socketKeepAlive }}
         {{- if .Values.mongo.uri }}
         uri: {{ .Values.mongo.uri }}
-        {{ else }}
+        {{- else if .Values.mongo.servers }}
+        servers:
+          {{- .Values.mongo.servers | nindent 10 }}
+        dbname: {{ .Values.mongo.dbname }}
+        {{- if (eq .Values.mongo.auth.enabled true) }}
+        username: {{ .Values.mongo.auth.username }}
+        password: {{ .Values.mongo.auth.password }}
+        {{- end }}
+        {{- else }}
         uri: mongodb://{{- if (eq .Values.mongo.auth.enabled true) }}{{ .Values.mongo.auth.username }}:{{ .Values.mongo.auth.password }}@{{- end }}{{ .Values.mongo.dbhost }}:{{ .Values.mongo.dbport }}/{{ .Values.mongo.dbname }}?{{- if .Values.mongo.rsEnabled }}&replicaSet={{ .Values.mongo.rs }}{{- end }}{{- if (eq .Values.mongo.auth.enabled true) }}&authSource={{ .Values.mongo.auth.source }}{{- end }}{{- if .Values.mongo.connectTimeoutMS }}&connectTimeoutMS={{ .Values.mongo.connectTimeoutMS }}{{- end }}
         {{- end }}
       {{- else if (eq .Values.management.type "jdbc") }}
@@ -67,11 +77,21 @@ data:
 
     oauth2:
       type: {{ .Values.oauth2.type | default "mongodb" }}
-      {{- if or (eq .Values.oauth2.type "mongodb") (kindIs "invalid" .Values.oauth2.type) }}
+     {{- if or (eq .Values.oauth2.type "mongodb") (kindIs "invalid" .Values.oauth2.type) }}
       mongodb:
+        sslEnabled: {{ .Values.mongo.sslEnabled }}
+        socketKeepAlive: {{ .Values.mongo.socketKeepAlive }}
         {{- if .Values.mongo.uri }}
         uri: {{ .Values.mongo.uri }}
-        {{ else }}
+        {{- else if .Values.mongo.servers }}
+        servers:
+          {{- .Values.mongo.servers | nindent 10 }}
+        dbname: {{ .Values.mongo.dbname }}
+        {{- if (eq .Values.mongo.auth.enabled true) }}
+        username: {{ .Values.mongo.auth.username }}
+        password: {{ .Values.mongo.auth.password }}
+        {{- end }}
+        {{- else }}
         uri: mongodb://{{- if (eq .Values.mongo.auth.enabled true) }}{{ .Values.mongo.auth.username }}:{{ .Values.mongo.auth.password }}@{{- end }}{{ .Values.mongo.dbhost }}:{{ .Values.mongo.dbport }}/{{ .Values.mongo.dbname }}?{{- if .Values.mongo.rsEnabled }}&replicaSet={{ .Values.mongo.rs }}{{- end }}{{- if (eq .Values.mongo.auth.enabled true) }}&authSource={{ .Values.mongo.auth.source }}{{- end }}{{- if .Values.mongo.connectTimeoutMS }}&connectTimeoutMS={{ .Values.mongo.connectTimeoutMS }}{{- end }}
         {{- end }}
       {{- else if (eq .Values.oauth2.type "jdbc") }}

--- a/am/templates/gateway/gateway-configmap.yaml
+++ b/am/templates/gateway/gateway-configmap.yaml
@@ -77,7 +77,7 @@ data:
 
     oauth2:
       type: {{ .Values.oauth2.type | default "mongodb" }}
-     {{- if or (eq .Values.oauth2.type "mongodb") (kindIs "invalid" .Values.oauth2.type) }}
+      {{- if or (eq .Values.oauth2.type "mongodb") (kindIs "invalid" .Values.oauth2.type) }}
       mongodb:
         sslEnabled: {{ .Values.mongo.sslEnabled }}
         socketKeepAlive: {{ .Values.mongo.socketKeepAlive }}


### PR DESCRIPTION
Currently am-gateway templates doesn't support mongodbconfiguration via ```.Values.mongo.servers```.

I have juste copy past mongodb configuration from am-management template and :
* added a if to remove password field form yaml file if it's define via environement variable.
* added the ability to define the authSource (missing mapping).

