### PR TITLE
feat(cockpit): add oidc configuration

### DIFF
--- a/cockpit/CHANGELOG.md
+++ b/cockpit/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to [Gravitee.io Cockpit](https://github.com/gravitee-io/helm-charts/tree/master/cockpit) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 1.2.0
+
+- Add OIDC idp configuration
+
 ### 1.1.0
 
 - Add Hazelcast configuration

--- a/cockpit/Chart.yaml
+++ b/cockpit/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 name: cockpit
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 1.1.0
-appVersion: 1.2.1
-description: Official Gravitee.io Helm chart for Cockpit 3.x
+version: 1.2.0
+appVersion: 1.3.0
+description: Official Gravitee.io Helm chart for Cockpit
 home: https://gravitee.io
 sources:
   - https://github.com/gravitee-io
@@ -21,5 +21,4 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/cockpit?modal=changelog
   artifacthub.io/changes: |
-    - Add Hazelcast configuration
-    - Add support for health check cron job attributes
+    - Add OIDC idp configuration

--- a/cockpit/README.adoc
+++ b/cockpit/README.adoc
@@ -154,8 +154,16 @@ $ helm install cockpit-1.0.0.tgz
 | api.ssl.enabled | bool | `false` |
 | api.updateStrategy.rollingUpdate.maxUnavailable | int | `1` |
 | api.updateStrategy.type | string | `"RollingUpdate"` |
+| authentication.github.clientId | string | `nil` |
 | authentication.github.clientSecret | string | `nil` |
+| authentication.google.clientId | string | `nil` |
 | authentication.google.clientSecret | string | `nil` |
+| authentication.oidc.clientId | string | `nil` |  |
+| authentication.oidc.clientSecret | string | `nil` |  |
+| authentication.oidc.accessTokenUri | string | `nil` |  |
+| authentication.oidc.userAuthorizationUri | string | `nil` |  |
+| authentication.oidc.userProfileUri | string | `nil` |  |
+| authentication.oidc.wellKnownUri | string | `nil` |  |
 | chaos.enabled | bool | `false` |
 | mongo.auth.enabled | bool | `false` |
 | mongo.auth.password | string | `nil` |

--- a/cockpit/templates/api/api-configmap.yaml
+++ b/cockpit/templates/api/api-configmap.yaml
@@ -191,47 +191,28 @@ data:
     auth:
       callbackUrl: {{ .Values.api.ingress.path }}/auth/login/callback
 
-      {{- if and .Values.authentication.github .Values.authentication.github.clientId }}
+      {{- if .Values.authentication.github }}
       github:
-        userAutorizationUri: https://github.com/login/oauth/authorize
-        accessTokenUri: https://github.com/login/oauth/access_token
-        userProfileUri: https://api.github.com/user
-        codeParameter: code
-        responseType: code
-        clientId: {{ .Values.authentication.github.clientId }}
-        clientSecret: {{ .Values.authentication.github.clientSecret }}
+        {{- if not .Values.authentication.github.redirectUri }}
         redirectUri: https://{{ index .Values.api.ingress.hosts 0 }}{{ .Values.api.ingress.path }}/auth/login/callback?provider=github
-        scopes:
-      {{- end }}
-
-      {{- if and .Values.authentication.google .Values.authentication.google.clientId }}
-      google:
-        userAutorizationUri: https://accounts.google.com/o/oauth2/v2/auth
-        accessTokenUri: https://oauth2.googleapis.com/token
-        userProfileUri: https://openidconnect.googleapis.com/v1/userinfo
-        codeParameter: code
-        responseType: code
-        clientId: {{ .Values.authentication.google.clientId }}
-        clientSecret: {{ .Values.authentication.google.clientSecret }}
-        redirectUri: https://{{ index .Values.api.ingress.hosts 0 }}{{ .Values.api.ingress.path }}/auth/login/callback?provider=google
-        scopes: openid,profile,email
-      {{- end }}
-
-      {{- if and .Values.authentication.oidc .Values.authentication.oidc.clientId }}
-      oidc:
-        {{- if and .Values.authentication.oidc.wellKnownUri }}
-        wellKnownUri: {{.Values.authentication.oidc.wellKnownUri}}
-        {{ else }}
-        userAuthorizationUri: {{.Values.authentication.oidc.userAuthorizationUri}}
-        accessTokenUri: {{.Values.authentication.oidc.accessTokenUri}}
-        userProfileUri: {{.Values.authentication.oidc.userProfileUri}}
         {{- end }}
-        codeParameter: code
-        responseType: code
-        clientId: {{ .Values.authentication.oidc.clientId }}
-        clientSecret: {{ .Values.authentication.oidc.clientSecret }}
+{{ toYaml .Values.authentication.github | indent 8 }}
+      {{- end }}
+
+      {{- if .Values.authentication.google }}
+      google:
+        {{- if not .Values.authentication.google.redirectUri }}
+        redirectUri: https://{{ index .Values.api.ingress.hosts 0 }}{{ .Values.api.ingress.path }}/auth/login/callback?provider=google
+        {{- end }}
+{{ toYaml .Values.authentication.google | indent 8 }}
+      {{- end }}
+
+      {{- if .Values.authentication.oidc }}
+      oidc:
+        {{- if not .Values.authentication.oidc.redirectUri }}
         redirectUri: https://{{ index .Values.api.ingress.hosts 0 }}{{ .Values.api.ingress.path }}/auth/login/callback?provider=oidc
-        scopes: openid,profile,email
+        {{- end }}
+{{ toYaml .Values.authentication.oidc | indent 8 }}
       {{- end }}
 
   hazelcast.xml: |

--- a/cockpit/templates/api/api-configmap.yaml
+++ b/cockpit/templates/api/api-configmap.yaml
@@ -216,6 +216,24 @@ data:
         redirectUri: https://{{ index .Values.api.ingress.hosts 0 }}{{ .Values.api.ingress.path }}/auth/login/callback?provider=google
         scopes: openid,profile,email
       {{- end }}
+
+      {{- if and .Values.authentication.oidc .Values.authentication.oidc.clientId }}
+      oidc:
+        {{- if and .Values.authentication.oidc.wellKnownUri }}
+        wellKnownUri: {{.Values.authentication.oidc.wellKnownUri}}
+        {{ else }}
+        userAuthorizationUri: {{.Values.authentication.oidc.userAuthorizationUri}}
+        accessTokenUri: {{.Values.authentication.oidc.accessTokenUri}}
+        userProfileUri: {{.Values.authentication.oidc.userProfileUri}}
+        {{- end }}
+        codeParameter: code
+        responseType: code
+        clientId: {{ .Values.authentication.oidc.clientId }}
+        clientSecret: {{ .Values.authentication.oidc.clientSecret }}
+        redirectUri: https://{{ index .Values.api.ingress.hosts 0 }}{{ .Values.api.ingress.path }}/auth/login/callback?provider=oidc
+        scopes: openid,profile,email
+      {{- end }}
+
   hazelcast.xml: |
     <?xml version="1.0" encoding="UTF-8"?>
     <hazelcast xmlns="http://www.hazelcast.com/schema/config"

--- a/cockpit/values.yaml
+++ b/cockpit/values.yaml
@@ -19,18 +19,28 @@ smtp:
 
 authentication:
   github:
-  #   clientId:
+    clientId:
     clientSecret:
+    userAutorizationUri: https://github.com/login/oauth/authorize
+    accessTokenUri: https://github.com/login/oauth/access_token
+    userProfileUri: https://api.github.com/user
+    codeParameter: code
+    responseType: code
   google:
-  #   clientId:
+    clientId:
     clientSecret:
+    userAutorizationUri: https://accounts.google.com/o/oauth2/v2/auth
+    accessTokenUri: https://oauth2.googleapis.com/token
+    userProfileUri: https://openidconnect.googleapis.com/v1/userinfo
+    codeParameter: code
+    responseType: code
+    scopes: openid,profile,email
   oidc:
-  #  clientId:
+    clientId:
     clientSecret:
-  #  wellKnownUri:
-    userAuthorizationUri:
-    accessTokenUri:
-    userProfileUri:
+    codeParameter: code
+    responseType: code
+    scopes: openid,profile,email
 
 mongo:
   # uri: mongodb://mongo-mongodb-replicaset:27017/gravitee?connectTimeoutMS=30000

--- a/cockpit/values.yaml
+++ b/cockpit/values.yaml
@@ -24,6 +24,13 @@ authentication:
   google:
   #   clientId:
     clientSecret:
+  oidc:
+  #  clientId:
+    clientSecret:
+  #  wellKnownUri:
+    userAuthorizationUri:
+    accessTokenUri:
+    userProfileUri:
 
 mongo:
   # uri: mongodb://mongo-mongodb-replicaset:27017/gravitee?connectTimeoutMS=30000


### PR DESCRIPTION
Add the OIDC idp configuration.

I took the opportunity to extract the authentication config into `values.yaml`. Therefore we won't need to update the charts to update the configuration for `github`, `google` and `oidc`.
However, we would need to update the chart if we add a new IDP.