### PR TITLE
feat: remove default admin (in memory) user for more security

### DIFF
--- a/apim/3.x/templates/api/api-configmap.yaml
+++ b/apim/3.x/templates/api/api-configmap.yaml
@@ -163,16 +163,10 @@ data:
           # - bcrypt : passwords are hashed with bcrypt
           # - none : passwords are not hashed/encrypted
           # default value is bcrypt
-          password-encoding-algo: bcrypt
+          password-encoding-algo: {{ .Values.inMemoryAuth.passwordEncodingAlgo | default bcrypt }}
           allow-email-in-search-results: {{ .Values.inMemoryAuth.allowEmailInSearchResults }}
           users:
             - user:
-              username: admin
-              password: {{ .Values.adminPasswordBcrypt }}
-              roles: ORGANIZATION:ADMIN, ENVIRONMENT:ADMIN
-              email: {{ .Values.adminEmail }}
-              firstName: {{ .Values.adminFirstName }}
-              lastName: {{ .Values.adminLastName }}
           {{- if .Values.extraInMemoryUsers -}}
           {{ .Values.extraInMemoryUsers | nindent 12 }}
           {{- end -}}

--- a/apim/3.x/templates/api/api-configmap.yaml
+++ b/apim/3.x/templates/api/api-configmap.yaml
@@ -167,6 +167,14 @@ data:
           allow-email-in-search-results: {{ .Values.inMemoryAuth.allowEmailInSearchResults }}
           users:
             - user:
+            {{- if .Values.adminAccountEnable }}
+              username: admin
+              password: {{ .Values.adminPasswordBcrypt }}
+              roles: ORGANIZATION:ADMIN, ENVIRONMENT:ADMIN
+              email: {{ .Values.adminEmail }}
+              firstName: {{ .Values.adminFirstName }}
+              lastName: {{ .Values.adminLastName }}
+            {{- end }}
           {{- if .Values.extraInMemoryUsers -}}
           {{ .Values.extraInMemoryUsers | nindent 12 }}
           {{- end -}}

--- a/apim/3.x/values.yaml
+++ b/apim/3.x/values.yaml
@@ -10,6 +10,7 @@ graviteeRepoAuth:
 inMemoryAuth:
   enabled: true
   allowEmailInSearchResults: false
+  passwordEncodingAlgo: bcrypt
 
 # Default password "admin", use bcrypt ($2a$ version) to generate a new one
 adminPasswordBcrypt: $2a$10$Ihk05VSds5rUSgMdsMVi9OKMIx2yUvMz7y9VP3rJmQeizZLrhLMyq

--- a/apim/3.x/values.yaml
+++ b/apim/3.x/values.yaml
@@ -12,15 +12,17 @@ inMemoryAuth:
   allowEmailInSearchResults: false
   passwordEncodingAlgo: bcrypt
 
+jwtSecret: myJWT4Gr4v1t33_S3cr3t
+
+# Define extra inMemory users here or disable the default ones here
+# By default, admin user will be added. If you want to remove the default admin turn the followong boolean to false. 
+adminAccountEnable: true
 # Default password "admin", use bcrypt ($2a$ version) to generate a new one
 adminPasswordBcrypt: $2a$10$Ihk05VSds5rUSgMdsMVi9OKMIx2yUvMz7y9VP3rJmQeizZLrhLMyq
 adminEmail:
 adminFirstName:
 adminLastName:
 
-jwtSecret: myJWT4Gr4v1t33_S3cr3t
-
-# Define extra inMemory users here or disable the default ones here
 extraInMemoryUsers: |
   - user:
     username: user


### PR DESCRIPTION
Hello,

We want to manage global algorithm encryption in values and remove the default admin user.

Breaking change : no more default admin in memory user.
If helm chart use want to keep the default admin user they must add the following entry in the values :

```yaml
    extraInMemoryUsers: |
      - user:
        username: <admin (or another username if you want to secure your access)>
        password: <your secudred password (bcrypt encoded if you let the default algo)>
        roles: ORGANIZATION:ADMIN, ENVIRONMENT:ADMIN
```

K.R.
Benjamin.