### PR TITLE
Fix typos in ES reporter lifecycle definition

### DIFF
--- a/apim/3.x/templates/gateway/gateway-configmap.yaml
+++ b/apim/3.x/templates/gateway/gateway-configmap.yaml
@@ -163,14 +163,14 @@ data:
         endpoints:
           {{ toYaml . | nindent 10 | trim -}}
         {{- end }}
-        {{- if (eq .Values.es.lifecyle.enabled true) }}
-        lifecyle:
-          policy_property_name: {{ .Values.es.lifecyle.policyPropertyName }}
+        {{- if (eq .Values.es.lifecycle.enabled true) }}
+        lifecycle:
+          policy_property_name: {{ .Values.es.lifecycle.policyPropertyName }}
           policies:
-            monitor: {{ .Values.es.lifecyle.policies.monitor }}
-            request: {{ .Values.es.lifecyle.policies.request }}
-            health: {{ .Values.es.lifecyle.policies.health }}
-            log: {{ .Values.es.lifecyle.policies.log }}
+            monitor: {{ .Values.es.lifecycle.policies.monitor }}
+            request: {{ .Values.es.lifecycle.policies.request }}
+            health: {{ .Values.es.lifecycle.policies.health }}
+            log: {{ .Values.es.lifecycle.policies.log }}
         {{- end }}
         {{- if (eq .Values.es.security.enabled true) }}
         security:

--- a/apim/3.x/values.yaml
+++ b/apim/3.x/values.yaml
@@ -234,7 +234,7 @@ es:
     enabled: false
     username: example
     password: example
-  lifecyle:
+  lifecycle:
     enabled: false
     policyPropertyName: index.lifecycle.name   #for openDistro, use 'opendistro.index_state_management.policy_id' instead of 'index.lifecycle.name'
     policies:


### PR DESCRIPTION
ILM for Elastic Search indexes templates does not work actually because of theses typos.