### PR TITLE
Update gravitee-am ingress descriptor to support k8s v1.22+

### DIFF
--- a/am/templates/api/api-ingress.yaml
+++ b/am/templates/api/api-ingress.yaml
@@ -3,7 +3,14 @@
 {{- $serviceAPIName := include "gravitee.api.fullname" . -}}
 {{- $serviceAPIPort := .Values.api.service.externalPort -}}
 {{- $ingressPath   := .Values.api.ingress.path -}}
-apiVersion: {{ template "ingress.apiVersion" . }}
+{{- $ingressPathType   := .Values.api.ingress.pathType | default "Prefix" -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ template "gravitee.api.fullname" . }}
@@ -21,14 +28,24 @@ metadata:
 spec:
   rules:
     {{- range $host := .Values.api.ingress.hosts }}
-    - host: {{ $host }}
+    - host: {{ $host | quote }}
       http:
         paths:
           - path: {{ $ingressPath }}
+            {{- if (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ $ingressPathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $serviceAPIName }}
+                port:
+                  number: {{ $serviceAPIPort }}
+              {{- else }}
               serviceName: {{ $serviceAPIName }}
               servicePort: {{ $serviceAPIPort }}
-    {{- end -}}
+              {{- end }}
+    {{- end }}
   {{- if .Values.api.ingress.tls }}
   tls:
 {{ toYaml .Values.api.ingress.tls | indent 4 }}

--- a/am/templates/gateway/gateway-ingress.yaml
+++ b/am/templates/gateway/gateway-ingress.yaml
@@ -3,7 +3,14 @@
 {{- $serviceGWName := include "gravitee.gateway.fullname" . -}}
 {{- $serviceGWPort := .Values.gateway.service.externalPort -}}
 {{- $ingressPath   := .Values.gateway.ingress.path -}}
-apiVersion: {{ template "ingress.apiVersion" . }}
+{{- $ingressPathType   := .Values.api.ingress.pathType | default "Prefix" -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ template "gravitee.gateway.fullname" . }}
@@ -25,9 +32,19 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            {{- if (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ $ingressPathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $serviceGWName }}
+                port:
+                  number: {{ $serviceGWPort }}
+              {{- else }}
               serviceName: {{ $serviceGWName }}
               servicePort: {{ $serviceGWPort }}
+              {{- end }}
     {{- end -}}
   {{- if .Values.gateway.ingress.tls }}
   tls:

--- a/am/templates/ui/ui-ingress.yaml
+++ b/am/templates/ui/ui-ingress.yaml
@@ -1,9 +1,16 @@
 {{- if .Values.ui.enabled -}}
 {{- if .Values.ui.ingress.enabled -}}
-{{- $serviceAPIName := include "gravitee.ui.fullname" . -}}
-{{- $serviceAPIPort := .Values.ui.service.externalPort -}}
+{{- $serviceUIName := include "gravitee.ui.fullname" . -}}
+{{- $serviceUIPort := .Values.ui.service.externalPort -}}
 {{- $ingressPath   := .Values.ui.ingress.path -}}
-apiVersion: {{ template "ingress.apiVersion" . }}
+{{- $ingressPathType   := .Values.api.ingress.pathType | default "Prefix" -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ template "gravitee.ui.fullname" . }}
@@ -25,9 +32,19 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            {{- if (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ $ingressPathType }}
+            {{- end }}
             backend:
-              serviceName: {{ $serviceAPIName }}
-              servicePort: {{ $serviceAPIPort }}
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $serviceUIName }}
+                port:
+                  number: {{ $serviceUIPort }}
+              {{- else }}
+              serviceName: {{ $serviceUIName }}
+              servicePort: {{ $serviceUIPort }}
+              {{- end }}
     {{- end -}}
   {{- if .Values.ui.ingress.tls }}
   tls:


### PR DESCRIPTION
This pull request add compatibility with k8s 1.22+ whose remove support of **extensions/v1beta1** and **networking.k8s.io/v1beta1** apiVersion for Ingress resource kind
https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122

And this remove warning when deploy on k8s v1.19+.

```

This PR is based on the default Helm chart Ingress template. I just adapt it to keep the same configuration in `values.yaml`.


