### PR TITLE
fix: trouble with automatic management URL

### DIFF
--- a/apim/3.x/templates/api/api-configmap.yaml
+++ b/apim/3.x/templates/api/api-configmap.yaml
@@ -34,8 +34,12 @@ data:
     {{- end }}
 
     management:
-      {{- if .Values.ui.ingress.enabled }}
-      url: https://{{ index .Values.ui.ingress.hosts 0 }}{{ regexFind "/[a-zA-Z]+" .Values.ui.ingress.path }}/
+      {{- if .Values.management.url }}
+      url: {{ Values.management.url}}
+      {{- else }}
+        {{- if .Values.ui.ingress.enabled }}
+        url: https://{{ index .Values.ui.ingress.hosts 0 }}{{ regexFind "/[a-zA-Z]+" .Values.ui.ingress.path }}/
+        {{- end }}
       {{- end }}
       type: {{ .Values.management.type | default "mongodb" }}
       {{- if or (eq .Values.management.type "mongodb") (kindIs "invalid" .Values.management.type) }}

--- a/apim/3.x/values.yaml
+++ b/apim/3.x/values.yaml
@@ -345,6 +345,7 @@ alerts:
 
 management:
   type: mongodb
+  url: your_public_ui_url
 
 ratelimit:
   type: mongodb


### PR DESCRIPTION
Our management public URL is not the ingress one.
We have a WAF Service in front of our ingress controller.
We change values to be able to change from default ingress value.