### PR TITLE
[feature] add harbor dockerhub_cache / private repo

### DIFF
--- a/apim/3.x/templates/api/api-deployment.yaml
+++ b/apim/3.x/templates/api/api-deployment.yaml
@@ -86,7 +86,11 @@ spec:
       initContainers:
         {{- if and .Values.jdbc.driver (eq .Values.management.type "jdbc") }}
         - name: get-repository-jdbc-ext
+          {{- if (eq .Values.harbor.enabled true) }}
+          image: "{{ .Values.harbor.repository.host }}/{{ .Values.harbor.repository.path }}/{{ .Values.harbor.repository.official }}/alpine"
+          {{- else }}
           image: 'alpine'
+          {{- end }}
           command: ['sh', '-c', "mkdir -p /tmp/plugins-ext && cd /tmp/plugins-ext && wget  {{ .Values.jdbc.driver }}"]
           securityContext: {{ toYaml ( .Values.api.securityContext | default .Values.api.deployment.securityContext ) | nindent 12 }}
           volumeMounts:
@@ -100,7 +104,11 @@ spec:
       {{- end }}
       containers:
         - name: {{ template "gravitee.api.fullname" . }}
+          {{- if (eq .Values.harbor.enabled true) }}
+          image: "{{ .Values.harbor.repository.host }}/{{ .Values.harbor.repository.path }}/{{ .Values.api.image.repository }}:{{ default .Chart.AppVersion .Values.api.image.tag }}"
+          {{- else }}
           image: "{{ .Values.api.image.repository }}:{{ default .Chart.AppVersion .Values.api.image.tag }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           securityContext: {{ toYaml ( .Values.api.securityContext | default .Values.api.deployment.securityContext ) | nindent 12 }}
           ports:

--- a/apim/3.x/templates/gateway/gateway-deployment.yaml
+++ b/apim/3.x/templates/gateway/gateway-deployment.yaml
@@ -84,18 +84,22 @@ spec:
       {{- if .Values.gateway.additionalPlugins -}}
         {{- $plugins = concat $plugins .Values.gateway.additionalPlugins -}}
       {{- end -}}
-    
+
       {{- if eq .Values.management.type "redis"  -}}
         {{- $url := printf "https://download.gravitee.io/graviteeio-apim/plugins/repositories/gravitee-repository-redis/gravitee-repository-redis-%s.zip"  (.Values.redis.repositoryVersion | default .Values.gateway.image.tag | default .Chart.AppVersion ) -}}
         {{- $plugins = append $plugins $url -}}
       {{- end -}}
-    
+
       {{- $pluginParams := dict "plugins" $plugins "appName" "graviteeio-gateway" "pluginsToRemove" .Values.gateway.removePlugins -}}
       {{- if or .Values.gateway.extraInitContainers $plugins .Values.jdbc.driver }}
       initContainers:
         {{- if and .Values.jdbc.driver (eq .Values.management.type "jdbc") }}
         - name: get-repository-jdbc-ext
+          {{- if (eq .Values.harbor.enabled true) }}
+          image: "{{ .Values.harbor.repository.host }}/{{ .Values.harbor.repository.path }}/{{ .Values.harbor.repository.official }}/alpine"
+          {{- else }}
           image: 'alpine'
+          {{- end }}
           command: ['sh', '-c', "mkdir -p /tmp/plugins-ext && cd /tmp/plugins-ext && wget  {{ .Values.jdbc.driver }}"]
           securityContext: {{ toYaml ( .Values.gateway.securityContext | default .Values.gateway.deployment.securityContext ) | nindent 12 }}
           volumeMounts:
@@ -107,13 +111,17 @@ spec:
         {{- tpl . $ | nindent 8 }}
         {{- end }}
       {{- end }}
-      {{- if .Values.gateway.services.kubeController.enabled }}          
+      {{- if .Values.gateway.services.kubeController.enabled }}
       serviceAccount: {{ .Values.gateway.services.kubeController.serviceAccount | default "default" }}
       serviceAccountName: {{ .Values.gateway.services.kubeController.serviceAccount | default "default" }}
       {{- end }}
       containers:
         - name: {{ template "gravitee.gateway.fullname" . }}
+          {{- if (eq .Values.harbor.enabled true) }}
+          image: "{{ .Values.harbor.repository.host }}/{{ .Values.harbor.repository.path }}/{{ .Values.gateway.image.repository }}:{{ default .Chart.AppVersion .Values.gateway.image.tag }}"
+          {{- else }}
           image: "{{ .Values.gateway.image.repository }}:{{ default .Chart.AppVersion .Values.gateway.image.tag }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
           securityContext: {{ toYaml ( .Values.gateway.securityContext | default .Values.gateway.deployment.securityContext ) | nindent 12 }}
           ports:

--- a/apim/3.x/templates/portal/portal-deployment.yaml
+++ b/apim/3.x/templates/portal/portal-deployment.yaml
@@ -79,7 +79,11 @@ spec:
     {{- end }}
       containers:
         - name: {{ template "gravitee.portal.fullname" . }}
+          {{- if (eq .Values.harbor.enabled true) }}
+          image: "{{ .Values.harbor.repository.host }}/{{ .Values.harbor.repository.path }}/{{ .Values.portal.image.repository }}:{{ default .Chart.AppVersion .Values.portal.image.tag }}"
+          {{- else }}
           image: "{{ .Values.portal.image.repository }}:{{ default .Chart.AppVersion .Values.portal.image.tag }}"
+          {{- end}}
           imagePullPolicy: {{ .Values.portal.image.pullPolicy }}
           securityContext: {{ toYaml ( .Values.portal.securityContext | default .Values.portal.deployment.securityContext ) | nindent 12 }}
           env:

--- a/apim/3.x/templates/ui/ui-deployment.yaml
+++ b/apim/3.x/templates/ui/ui-deployment.yaml
@@ -79,7 +79,11 @@ spec:
     {{- end }}
       containers:
         - name: {{ template "gravitee.ui.fullname" . }}
+          {{- if (eq .Values.harbor.enabled true) }}
+          image: "{{ .Values.harbor.repository.host }}/{{ .Values.harbor.repository.path }}/{{ .Values.ui.image.repository }}:{{ default .Chart.AppVersion .Values.ui.image.tag }}"
+          {{- else }}
           image: "{{ .Values.ui.image.repository }}:{{ default .Chart.AppVersion .Values.ui.image.tag }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
           securityContext: {{ toYaml ( .Values.ui.securityContext | default .Values.ui.deployment.securityContext ) | nindent 12 }}
           env:

--- a/apim/3.x/values.yaml
+++ b/apim/3.x/values.yaml
@@ -7,6 +7,16 @@ chaos:
 graviteeRepoAuth:
   enabled: true
 
+# Some k8s environments have no direct internet access.
+# Users of harbor with dockerhub-cache will want to enable this to get the image path like:
+# my.harbor.host.tld/dockerhub-cache/<repo>/<image>
+harbor:
+  enabled: false
+  repository:
+    host: my.harbor.host.tld
+    path: dockerhub-cache
+    official: library  # official docker containers (like alpine) are in the library repo when using dockerhub-cache.
+
 inMemoryAuth:
   enabled: true
   allowEmailInSearchResults: false
@@ -15,7 +25,7 @@ inMemoryAuth:
 jwtSecret: myJWT4Gr4v1t33_S3cr3t
 
 # Define extra inMemory users here or disable the default ones here
-# By default, admin user will be added. If you want to remove the default admin turn the followong boolean to false. 
+# By default, admin user will be added. If you want to remove the default admin turn the followong boolean to false.
 adminAccountEnable: true
 # Default password "admin", use bcrypt ($2a$ version) to generate a new one
 adminPasswordBcrypt: $2a$10$Ihk05VSds5rUSgMdsMVi9OKMIx2yUvMz7y9VP3rJmQeizZLrhLMyq
@@ -184,7 +194,7 @@ jdbc:
   # the version of the gravitee-repository-jdbc (only required for apim versions < 3.5.0)
 #  repositoryVersion: 3.3.0
   username:
-  password: 
+  password:
   liquibase: true
   schema: public
   pool:
@@ -391,7 +401,7 @@ api:
       runAsNonRoot: true
 
   livenessProbe:
-    tcpSocket:  
+    tcpSocket:
       port: http
     initialDelaySeconds: 30
     periodSeconds: 30
@@ -470,7 +480,7 @@ api:
 #          annotations:
 #            kubernetes.io/ingress.class: nginx
 #            nginx.ingress.kubernetes.io/rewrite-target: /_$1
-        service: 
+        service:
 #       If you choose to enable this service, you'll need to expose the technical api
 #       on an accessible host outside of the pod: api.http.services.core.http.host
           enabled: false
@@ -617,7 +627,7 @@ gateway:
       runAsNonRoot: true
 
   livenessProbe:
-    tcpSocket:  
+    tcpSocket:
       port: http
     initialDelaySeconds: 30
     periodSeconds: 30
@@ -668,11 +678,11 @@ gateway:
       # host:
       # port:
       # password:
-  management: 
+  management:
     http:
-      # url: 
-      # username: 
-      # pssword: 
+      # url:
+      # username:
+      # pssword:
       # ssl:
       #   trustall: true
       #   verifyHostname: true
@@ -712,7 +722,7 @@ gateway:
 #          annotations:
 #            kubernetes.io/ingress.class: nginx
 #            nginx.ingress.kubernetes.io/rewrite-target: /_$1
-      service: 
+      service:
 #       If you choose to enable this service, you'll need to expose the technical api
 #       on an accessible host outside of the pod: api.http.services.core.http.host
         enabled: false
@@ -912,7 +922,7 @@ portal:
     initialDelaySeconds: 10
     periodSeconds: 30
     failureThreshold: 3
-            
+
   podAnnotations: {}
     # iam.amazonaws.com/role: es-cluster
 
@@ -1058,7 +1068,7 @@ ui:
     failureThreshold: 3
 
   podAnnotations: {}
-    # iam.amazonaws.com/role: es-cluster 
+    # iam.amazonaws.com/role: es-cluster
 
   # How long to wait for APIM Console pods to stop gracefully
   terminationGracePeriod: 30


### PR DESCRIPTION
Some kubernetes environments have no direct internet connection and
rely on a solution like harbor to proxy the container downloads.

There was no clean solution to configure this, as the image paths for
the alpine init containers where hardcoded in the template.

This change makes use of a harbor repository easily and configurable.
But it can also be used for other container repo's or caches.

In our situation harbor's dockerhub-cache runs at:
`some.harbor.local/dockerhub-cache/<repo>/<image>`

configure in values.yml:
```
harbor:
  enabled: true
  repository:
    host: some.harbor.local
    path: dockerhub-cache
    official: library
```

resulting alpine image: `some.harbor.local/dockerhub-cache/library/alpine`
resulting gravitee image: `some.harbor.local/dockerhub-cache/graviteeio/apim-<image>:<tag>`