### PR TITLE
fix: update swagger generator url in cockpit helm chart

### DIFF
--- a/cockpit/templates/api/api-configmap.yaml
+++ b/cockpit/templates/api/api-configmap.yaml
@@ -55,7 +55,7 @@ data:
 
     {{- if .Values.generator.enabled }}
     swaggerGenerator:
-      url: http://{{ template "gravitee.generator.fullname" . }}:{{ .Values.generator.service.externalPort }}
+      url: http://{{ template "gravitee.generator.fullname" . }}:{{ .Values.generator.service.externalPort }}/
       apiKey: {{ .Values.generator.apiKey }}
     {{- end }}
 


### PR DESCRIPTION
## Description

Update swagger generator url.

Linked to https://github.com/gravitee-io/gravitee-cockpit/pull/1099