### PR TITLE
chore: bump version to 3.1.31 and update changelog, adding support for ILM managed indexes

### DIFF
--- a/apim/3.x/CHANGELOG.md
+++ b/apim/3.x/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 3.1.31
+
+- [X] Add support for ILM managed indexes
+
 ### 3.1.30 
 
 - [X] Add support for startupProbe

--- a/apim/3.x/Chart.yaml
+++ b/apim/3.x/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: apim3
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 3.1.30
+version: 3.1.31
 appVersion: 3.11.2
 description: Official Gravitee.io Helm chart for API Management 3.x
 home: https://gravitee.io
@@ -20,4 +20,4 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/apim3?modal=changelog
   artifacthub.io/changes: |
-    - Add support for startupProbe
+    - Add support for ILM managed indexes


### PR DESCRIPTION
chore: bump version to 3.1.31 and update changelog, adding support for ILM managed indexes

https://github.com/gravitee-io/issues/issues/6507