### PR TITLE
fix: nginx must pass if-match header

### DIFF
--- a/apim/3.x/CHANGELOG.md
+++ b/apim/3.x/CHANGELOG.md
@@ -5,6 +5,7 @@ This file documents all notable changes to [Gravitee.io API Management 3.x](http
 ### 3.1.31
 
 - [X] Add support for ILM managed indexes
+- [X] Remove the empty override of 'if-match' header
 
 ### 3.1.30 
 

--- a/apim/3.x/values.yaml
+++ b/apim/3.x/values.yaml
@@ -528,7 +528,7 @@ api:
         - apim.example.com
       annotations:
         kubernetes.io/ingress.class: nginx
-        nginx.ingress.kubernetes.io/configuration-snippet: "etag on;\nproxy_pass_header ETag;\nproxy_set_header if-match \"\";\n"
+        nginx.ingress.kubernetes.io/configuration-snippet: "etag on;\nproxy_pass_header ETag;\nproxy_pass_header if-match;\n"
         # kubernetes.io/tls-acme: "true"
       #tls:
         # Secrets must be manually created in the namespace.


### PR DESCRIPTION
gravitee-io/issues#6624

## Context

In APIM, if an API is modified by multiple users at the same time, only the first can modify it. The following wil need to refresh the page. This mechanism is implemented by using ETag and if-match headers;

## Resolution

In our configuration, if-match header is overridden with an empty string. This fix tells to nginx to pass the header as usual.

⚠️ unable to test locally
