### PR TITLE
feat: allow "latest" versions of APIM branches

### DIFF
--- a/apim/3.x/templates/_helpers.tpl
+++ b/apim/3.x/templates/_helpers.tpl
@@ -121,7 +121,7 @@ Create initContainers for downloading plugins ext plugin-ext
 
 {{- define "ratelimit.plugin" -}}
 {{- $version := (.Values.redis.repositoryVersion | default .Values.gateway.image.tag | default .Chart.AppVersion ) -}}
-{{- if eq $version "nightly" -}}
+{{- if or (eq "nightly" $version) (contains "latest" $version) -}}
   {{- printf "https://download.gravitee.io/graviteeio-apim/plugins/repositories/gravitee-apim-repository-redis/gravitee-apim-repository-redis-%s.zip" (.Values.redis.repositoryVersion | default .Chart.AppVersion) -}}
 {{- else if $version | semverCompare "<=3.5.18" -}}
   {{- printf "https://download.gravitee.io/graviteeio-apim/plugins/repositories/gravitee-repository-redis/gravitee-repository-redis-%s.zip" $version -}}

--- a/apim/3.x/tests/gateway/deployment_redis_test.yaml
+++ b/apim/3.x/tests/gateway/deployment_redis_test.yaml
@@ -127,3 +127,44 @@ tests:
             volumeMounts:
             - name: graviteeio-apim-plugins
               mountPath: /tmp/plugins
+
+  - it: Check redis plugin with latest version of image (should be 3.11.2)
+    template: gateway/gateway-deployment.yaml
+    set:
+        ratelimit:
+            type: "redis"
+        gateway:
+            image:
+                tag: master-latest
+            ratelimit:
+                redis:
+                    host: localhost
+    asserts:
+        - hasDocuments:
+              count: 1
+        - equal:
+              path: spec.template.spec.containers[0].volumeMounts[1].name
+              value: graviteeio-apim-plugins
+        - equal:
+              path: spec.template.spec.containers[0].volumeMounts[1].mountPath
+              value: /opt/graviteeio-gateway/plugins-ext
+        - equal:
+              path: spec.template.spec.volumes[1].name
+              value: graviteeio-apim-plugins
+        - equal:
+              path: spec.template.spec.volumes[1].emptyDir
+              value: {}
+        - contains:
+              path: spec.template.spec.initContainers
+              content:
+                  name: get-plugins
+                  image: "alpine:latest"
+                  imagePullPolicy: Always
+                  command: ['sh', '-c', "mkdir -p /tmp/plugins && cd /tmp/plugins && wget https://download.gravitee.io/graviteeio-apim/plugins/repositories/gravitee-apim-repository-redis/gravitee-apim-repository-redis-3.11.2.zip"]
+                  env: []
+                  securityContext:
+                      runAsNonRoot: true
+                      runAsUser: 1001
+                  volumeMounts:
+                      - name: graviteeio-apim-plugins
+                        mountPath: /tmp/plugins


### PR DESCRIPTION
Since the CI process of APIM generates images with this template name: `${branch}-latest`, we would like to allow them to be used in helm.
It's like nightly for master but extended to support branches:
 - master-latest
 - 3.5.x-latest
 - 3.10.x-latest
 - ...