### PR TITLE
chore: disable old classloader to use the new one by default

### DIFF
--- a/apim/3.x/.helmignore
+++ b/apim/3.x/.helmignore
@@ -15,8 +15,11 @@
 *.bak
 *.tmp
 *~
+# Previous helm packages
+apim3-*.tgz
 # Various IDEs
 .project
 .idea/
 *.tmproj
 private/
+TESTS.md

--- a/apim/3.x/CHANGELOG.md
+++ b/apim/3.x/CHANGELOG.md
@@ -4,6 +4,8 @@ This file documents all notable changes to [Gravitee.io API Management 3.x](http
 
 ### 3.1.33
 
+- Disable old classloader to enable the new one by default (since v3.15)
+- Add support for kubernetes certificate configuration
 - Make app.kubernetes.io/version label consistent
 - Add quotes to version to fix #6450
 

--- a/apim/3.x/templates/gateway/gateway-configmap.yaml
+++ b/apim/3.x/templates/gateway/gateway-configmap.yaml
@@ -370,7 +370,12 @@ data:
       alert-engine-connector-ws:
         enabled: false
     {{- end }}
-        
+
+    # Old class loader behavior, false by default
+    classloader:
+      legacy:
+        enabled: {{ .Values.gateway.classloader.legacy.enabled }}
+
   {{- if .Values.gateway.logging.debug }}
   logback.xml: |
     <?xml version="1.0" encoding="UTF-8"?>

--- a/apim/3.x/values.yaml
+++ b/apim/3.x/values.yaml
@@ -818,6 +818,10 @@ gateway:
 #      port: 8379
 #    file:
 
+  classloader:
+    legacy:
+      enabled: false
+
   # DEPRECATED: This part will be removed shortly in favor of gateway.policy (see below)
   apiKey:
     header: X-Gravitee-Api-Key


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6988

**Description**

The new classloader system used on the gateway side wasn't activated by default in the code.