### PR TITLE
fix: allow to configure readinessProbe using administration endpoint

### DIFF
--- a/am/CHANGELOG.md
+++ b/am/CHANGELOG.md
@@ -8,6 +8,7 @@ This file documents all notable changes to [Gravitee.io Access Management 3.x](h
 - [X] Add quotes to version to fix #6450
 - [X] Add ServiceAccount to all deployments
 - Update gravitee.io AM v3.15.0
+- Improve AM Gateway readinessProbe configuration
 
 ### 1.0.33
 

--- a/am/Chart.yaml
+++ b/am/Chart.yaml
@@ -26,3 +26,4 @@ annotations:
     - Make app.kubernetes.io/version label consistent
     - Add quotes to version to fix #6450
     - Add ServiceAccount to all deployments
+    - Improve AM Gateway readinessProbe configuration

--- a/am/templates/gateway/gateway-deployment.yaml
+++ b/am/templates/gateway/gateway-deployment.yaml
@@ -123,7 +123,29 @@ spec:
             {{- end }}
           {{- end }}
           livenessProbe: {{ toYaml .Values.gateway.livenessProbe | nindent 12 }}
-          readinessProbe: {{ toYaml .Values.gateway.readinessProbe | nindent 12 }}
+          readinessProbe:
+            {{- if eq .Values.gateway.readinessProbe.domainSync true }}
+            httpGet:
+              path: /_node/health?probes=security-domain-sync
+              port: {{ .Values.gateway.services.core.http.port | default 18082 }}
+              {{- if eq .Values.gateway.services.core.http.secured true}}
+              scheme: HTTPS
+              {{- end }}
+              {{- if eq .Values.gateway.services.core.http.authentication.type "basic" }}
+              httpHeaders:
+                - name: Authorization
+                  value: {{ print "Basic "}}{{print "admin:" .Values.gateway.services.core.http.authentication.password | b64enc }}
+              {{- end }}
+            initialDelaySeconds: {{ .Values.gateway.readinessProbe.initialDelaySeconds | default 5 }}
+            failureThreshold: {{ .Values.gateway.readinessProbe.failureThreshold | default 3 }}
+            periodSeconds: {{ .Values.gateway.readinessProbe.periodSeconds | default 30 }}
+            {{- else }}
+            {{- $readinessProbe := unset (.Values.gateway.readinessProbe | deepCopy) "domainSync" -}}
+            {{ toYaml $readinessProbe | nindent 12 }}
+            {{- end }}
+          {{- if and (.Values.gateway.startupProbe) (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+          startupProbe: {{ toYaml .Values.gateway.startupProbe | nindent 12 }}
+          {{- end }}
           resources: {{ toYaml .Values.gateway.resources | nindent 12 }}
           volumeMounts:
             - name: config

--- a/am/values.yaml
+++ b/am/values.yaml
@@ -373,16 +373,19 @@ gateway:
     # revisionHistoryLimit: 10
 
   livenessProbe:
-    tcpSocket:
+    tcpSocket:  
       port: http
     initialDelaySeconds: 30
     periodSeconds: 30
     failureThreshold: 3
 
   readinessProbe:
+    # use the node endpoint as readinessProbe to test the domain synchronization
+    # in this case, the gateway.services.core.http.host must be defined to the Pod IP or 0.0.0.0
+    domainSync: false
     tcpSocket:
       port: http
-    initialDelaySeconds: 30
+    initialDelaySeconds: 10
     periodSeconds: 30
     failureThreshold: 3
 


### PR DESCRIPTION
fixes gravitee-io/issues#7045
