### PR TITLE
Set default endpoint to the url of the gateway

### DIFF
--- a/apim/3.x/CHANGELOG.md
+++ b/apim/3.x/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 3.1.35
+
+- Set default entrypoint for Portal Try-it and cURL to the url of the gateway
+
 ### 3.1.34
 
 - Ease the integration of Gravitee.io Cockpit

--- a/apim/3.x/templates/api/api-deployment.yaml
+++ b/apim/3.x/templates/api/api-deployment.yaml
@@ -138,6 +138,10 @@ spec:
             - name: gravitee_cockpit_ssl_verifyHostname
               value: "{{ .Values.cockpit.ssl.verifyHostname }}"
             {{- end }}
+            {{- if .Values.gateway.enabled }}
+            - name: portal.entrypoint
+              value: "https://{{ index .Values.gateway.ingress.hosts 0 }}{{ .Values.gateway.ingress.path }}"
+            {{- end }}
 {{- if .Values.api.env | default .Values.api.deployment.extraEnvs }}
 {{ toYaml ( .Values.api.env | default .Values.api.deployment.extraEnvs ) | indent 12 }}
 {{- end }}

--- a/apim/3.x/tests/api/deployment_test.yaml
+++ b/apim/3.x/tests/api/deployment_test.yaml
@@ -15,9 +15,11 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: graviteeio/apim-management-api:3.15.2
-      - isEmpty:
-          # It should not contain environment variable by default
+      - equal:
           path: spec.template.spec.containers[0].env
+          value:
+            - name: portal.entrypoint
+              value: https://apim.example.com/gateway
       - isEmpty:
           # It should not contain init containers by default
           path: spec.template.spec.initContainers


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7169

**Description**

This change sets the `portal.endpoint` of the API-service to the gateway endpoint

**Additional context**

With this change the Swagger-UI has the gateway set as the default server