### PR TITLE
Handle jwt attributes in APIM Management API

### DIFF
--- a/apim/3.x/templates/api/api-configmap.yaml
+++ b/apim/3.x/templates/api/api-configmap.yaml
@@ -342,13 +342,13 @@ data:
       secret: {{ .Values.jwtSecret }}
       {{- if .Values.jwt }}
       # Allows to define the end of validity of the token in seconds (default 604800 = a week)
-      #expire-after: 604800
+      expire-after: {{ .Values.jwt.expireAfter | default 604800 }}
       # Allows to define the end of validity of the token in seconds for email registration (default 86400 = a day)
-      #email-registration-expire-after: 86400
+      email-registration-expire-after: {{ .Values.jwt.emailRegistrationExpireAfter | default 86400 }}
       # Allows to define issuer (default gravitee-management-auth)
-      #issuer: gravitee-management-auth
+      issuer: {{ .Values.jwt.issuer | default "gravitee-management-auth" }}
       # Allows to define cookie context path (default /)
-      #cookie-path: /
+      cookie-path: {{ ((.Values.jwt.cookie).path) | default "/" }}
       # Allows to define cookie domain (default "")
       {{- if .Values.jwt.cookie }}
       cookie-domain: {{ .Values.jwt.cookie.domain }}
@@ -356,7 +356,7 @@ data:
       cookie-domain: {{ index .Values.ui.ingress.hosts 0 }}
       {{- end }}
       # Allows to define if cookie secure only (default false)
-      #cookie-secure: true
+      cookie-secure: {{ ((.Values.jwt.cookie).secure) | default false }}
       {{- end }}
 
     swagger:

--- a/apim/3.x/tests/api/configmap_test.yaml
+++ b/apim/3.x/tests/api/configmap_test.yaml
@@ -1,0 +1,58 @@
+suite: Test Management API default configmap
+templates:
+  - "api/api-configmap.yaml"
+tests:
+  - it: Set jwt attributes with default values if not set
+    template: api/api-configmap.yaml
+    set:
+      jwt:
+        key: value
+    asserts:
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "expire-after: 604800"
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "email-registration-expire-after: 86400"
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "issuer: gravitee-management-auth"
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "cookie-path: /"
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "cookie-domain: apim.example.com"
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "cookie-secure: false"
+  - it: Set jwt attributes with provided values
+    template: api/api-configmap.yaml
+    set:
+      jwt:
+        expireAfter: 1000
+        emailRegistrationExpireAfter: 2000
+        issuer: "gravitee-management-auth-test"
+        cookie:
+          path: "/test"
+          domain: "apim.test"
+          secure: true
+    asserts:
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "expire-after: 1000"
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "email-registration-expire-after: 2000"
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "issuer: gravitee-management-auth-test"
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "cookie-path: /test"
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "cookie-domain: apim.test"
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "cookie-secure: true"


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7023

**Description**

I added `jwt` attributes in APIM Management API configmap.
Regarding the naming I followed the convention started by `cookie-domain: {{ .Values.jwt.cookie.domain }}`