### PR TITLE
feat(cockpit): add default api designer model creation limit

### DIFF
--- a/cockpit/CHANGELOG.md
+++ b/cockpit/CHANGELOG.md
@@ -5,6 +5,7 @@ This file documents all notable changes to [Gravitee.io Cockpit](https://github.
 ### 1.6.10
 
 - [X] Fix default plan attributes
+- [X] Add API Designer default model creation limit
 
 ### 1.6.9
 

--- a/cockpit/Chart.yaml
+++ b/cockpit/Chart.yaml
@@ -22,3 +22,4 @@ annotations:
   # https://artifacthub.io/packages/helm/graviteeio/cockpit?modal=changelog
   artifacthub.io/changes: |
     - Fix default plan attributes
+    - Add API Designer default model creation limit

--- a/cockpit/values.yaml
+++ b/cockpit/values.yaml
@@ -355,14 +355,17 @@ api:
       maxEnvs: 2
       isDefault: 'true'
       dataRetentionDuration: 1
+      maxDesignerModelsCount: 1
     medium:
       name: 'Medium'
       maxEnvs: 4
       dataRetentionDuration: 30
+      maxDesignerModelsCount: 1
     large:
       name: 'Large'
       maxEnvs: -1
       dataRetentionDuration: 182
+      maxDesignerModelsCount: 1
   services:
     healthCheckPurge:
       cron: "0 0 0 */1 * *"


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/gravitee-cockpit/issues/1541

**Description**

Add default api designer model creation limit.