### PR TITLE
docs: fix syntax in README.adoc

### DIFF
--- a/cockpit/README.adoc
+++ b/cockpit/README.adoc
@@ -238,3 +238,4 @@ $ helm install cockpit-1.0.0.tgz
 | ui.service.internalPortName | string | `"http"` |
 | ui.service.name | string | `"nginx"` |
 | ui.service.type | string | `"ClusterIP"` |
+|===


### PR DESCRIPTION
**Description**

Fix "unterminated table block" error.
