### PR TITLE
fix(cockpit): fix api url environment variable name

### DIFF
--- a/cockpit/templates/ui/ui-deployment.yaml
+++ b/cockpit/templates/ui/ui-deployment.yaml
@@ -85,7 +85,7 @@ spec:
           securityContext:
 {{ toYaml .Values.ui.securityContext | trim | indent 12 }}
           env:
-            - name: MGMT_API_URL
+            - name: API_URL
               value: "https://{{index .Values.api.ingress.hosts 0 }}{{ .Values.api.ingress.path }}/"
 {{- if .Values.ui.env | default .Values.ui.deployment.extraEnvs }}
 {{ toYaml ( .Values.ui.env | default .Values.ui.deployment.extraEnvs ) | indent 12 }}

--- a/cockpit/tests/ui/ui-deployment_test.yaml
+++ b/cockpit/tests/ui/ui-deployment_test.yaml
@@ -82,7 +82,7 @@ tests:
             affinity: {}
             containers:
             - env:
-              - name: MGMT_API_URL
+              - name: API_URL
                 value: https://cockpit.example.com/management/
               envFrom: []
               image: graviteeio/cockpit-management-ui:1.0.0-app


### PR DESCRIPTION
**Description**

The environment variable was incorrect. Cockpit UI docker image was expecting `API_URL` to configure the management API URL in `constants.json`.

It seems we didn't notice this before because it seems the Management UI image was not using the file "generated" by confd. I was using the file embedded in the zip and this file was containing `/api` as `baseURL` 🤯 

This bug has risen when we migrated Cockpit Management UI to use our `graviteeio/nginx` base image.