### PR TITLE
fix(apim): deploy gateway specific version with default ratelimit

### DIFF
--- a/apim/3.x/templates/gateway/gateway-deployment.yaml
+++ b/apim/3.x/templates/gateway/gateway-deployment.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.gateway.enabled -}}
 {{- $initContainers := .Values.initContainers -}}
-{{- $rateLimitPlugin := include "ratelimit.plugin" . -}}
 apiVersion: apps/v1
 kind: {{ .Values.gateway.type }}
 metadata:
@@ -88,7 +87,8 @@ spec:
         {{- $plugins = concat $plugins .Values.gateway.additionalPlugins -}}
       {{- end -}}
     
-      {{- if eq .Values.ratelimit.type "redis"  -}}       
+      {{- if eq .Values.ratelimit.type "redis"  -}}
+        {{- $rateLimitPlugin := include "ratelimit.plugin" . -}}
         {{- $plugins = append $plugins $rateLimitPlugin -}}
       {{- end -}}
 

--- a/apim/3.x/tests/gateway/deployment_test.yaml
+++ b/apim/3.x/tests/gateway/deployment_test.yaml
@@ -22,6 +22,29 @@ tests:
           # It should not contain init containers by default
           path: spec.template.spec.initContainers
 
+  - it: Check deploy specific APIM version
+    template: gateway/gateway-deployment.yaml
+    set:
+      gateway:
+        image:
+          tag: 3.17
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: graviteeio/apim-gateway:3.17
+      - isEmpty:
+          # It should not contain environment variable by default
+          path: spec.template.spec.containers[0].env
+      - isEmpty:
+          # It should not contain init containers by default
+          path: spec.template.spec.initContainers
+
   - it: Check deployment with revisionHistoryLimit
     template: gateway/gateway-deployment.yaml
     set:
@@ -86,4 +109,3 @@ tests:
           path: spec.template.spec.containers[0].ports[1].name
           # There is a k8s limitation that port names must be 15 characters or less
           pattern: ^.{0,15}$
-


### PR DESCRIPTION
**Description**

Deploying a specific version of the Gateway using the default RateLimit plugin (mongo)
is throwing the following error:

```
Error: template: apim3/templates/gateway/gateway-deployment.yaml:3:24: executing "apim3/templates/gateway/gateway-deployment.yaml" at <include "ratelimit.plugin" .>: error calling include: template: apim3/templates/_helpers.tpl:124:11: executing "ratelimit.plugin" at <eq "nightly" $version>: error calling eq: incompatible types for comparison

```
Moving the 'ratelimit.plugin' helper execution in the if block fixed the issue.
