### PR TITLE
fix(apim): add template to APIM Cockpit secret name

### DIFF
--- a/apim/3.x/CHANGELOG.md
+++ b/apim/3.x/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 3.1.37
+
+- Add template to APIM Cockpit secret name
+
 ### 3.1.36
 
 - Fix deploy gateway specific version with default ratelimit

--- a/apim/3.x/Chart.yaml
+++ b/apim/3.x/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: apim3
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 3.1.36
+version: 3.1.37
 appVersion: 3.15.2
 description: Official Gravitee.io Helm chart for API Management 3.x
 home: https://gravitee.io
@@ -20,4 +20,4 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/apim3?modal=changelog
   artifacthub.io/changes: |
-    - Fix deploy gateway specific version with default ratelimit
+    - Add template to APIM Cockpit secret name

--- a/apim/3.x/templates/api/api-deployment.yaml
+++ b/apim/3.x/templates/api/api-deployment.yaml
@@ -211,7 +211,7 @@ spec:
         {{- if .Values.cockpit.enabled }}
         - name: gravitee-cockpit-certificates
           secret:
-            secretName: gravitee-cockpit-certificates
+            secretName: {{ template "gravitee.api.fullname" . }}-cockpit-certificates
         {{- end }}
         {{- include "deployment.pluginVolumes" $pluginParams | indent 8 }}
         {{- with .Values.api.extraVolumes }}

--- a/apim/3.x/templates/cockpit/cockpit-certificates.yaml
+++ b/apim/3.x/templates/cockpit/cockpit-certificates.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: gravitee-cockpit-certificates
+  name: {{ template "gravitee.api.fullname" . }}-cockpit-certificates
 data:
   keystore.p12: {{ .Values.cockpit.keystore.value }}
   {{- if .Values.cockpit.truststore }}

--- a/apim/3.x/tests/cockpit/configmap_test.yaml
+++ b/apim/3.x/tests/cockpit/configmap_test.yaml
@@ -25,7 +25,7 @@ tests:
           of: v1
       - equal:
           path: metadata.name
-          value: gravitee-cockpit-certificates
+          value:  RELEASE-NAME-apim3-api-cockpit-certificates
       - equal:
           path: data
           value:


### PR DESCRIPTION
**Description**

The Cockpit secret name was hardcoded. It prevented deploying multiple APIM releases in the same namespace

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
