### PR TITLE
APIM: Add support for `keystore` and `truststore` in MongoDB config

### DIFF
--- a/apim/3.x/CHANGELOG.md
+++ b/apim/3.x/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 3.1.46
+
+- Add support for keystore and truststore in MongoDB configuration
+
 ### 3.1.45
 
 - [X] Add version labels on pods

--- a/apim/3.x/Chart.yaml
+++ b/apim/3.x/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: apim3
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 3.1.45
+version: 3.1.46
 appVersion: 3.15.8
 description: Official Gravitee.io Helm chart for API Management 3.x
 home: https://gravitee.io
@@ -20,4 +20,4 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/apim3?modal=changelog
   artifacthub.io/changes: |
-    - Add version labels on pods
+    - Add support for keystore and truststore in MongoDB configuration

--- a/apim/3.x/templates/api/api-configmap.yaml
+++ b/apim/3.x/templates/api/api-configmap.yaml
@@ -58,6 +58,14 @@ data:
         {{- else }}
         uri: mongodb://{{- if (eq .Values.mongo.auth.enabled true) }}{{ .Values.mongo.auth.username }}:{{ .Values.mongo.auth.password }}@{{- end }}{{ .Values.mongo.dbhost }}:{{ .Values.mongo.dbport }}/{{ .Values.mongo.dbname }}?{{- if .Values.mongo.rsEnabled }}&replicaSet={{ .Values.mongo.rs }}{{- end }}{{- if (eq .Values.mongo.auth.enabled true) }}&authSource={{ .Values.mongo.auth.source }}{{- end }}{{- if .Values.mongo.connectTimeoutMS }}&connectTimeoutMS={{ .Values.mongo.connectTimeoutMS }}{{- end }}
         {{- end }}
+        {{- if .Values.mongo.keystore }}
+        keystore:
+        {{- toYaml .Values.mongo.keystore | nindent 10 }}
+        {{- end }}
+        {{- if .Values.mongo.truststore }}
+        truststore:
+        {{- toYaml .Values.mongo.truststore | nindent 10 }}
+        {{- end }}
       {{- else if (eq .Values.management.type "jdbc") }}
       jdbc:
         url: {{ .Values.jdbc.url }}

--- a/apim/3.x/templates/gateway/gateway-configmap.yaml
+++ b/apim/3.x/templates/gateway/gateway-configmap.yaml
@@ -69,6 +69,14 @@ data:
         {{- else }}
         uri: mongodb://{{- if (eq .Values.mongo.auth.enabled true) }}{{ .Values.mongo.auth.username }}:{{ .Values.mongo.auth.password }}@{{- end }}{{ .Values.mongo.dbhost }}:{{ .Values.mongo.dbport }}/{{ .Values.mongo.dbname }}?{{- if .Values.mongo.rsEnabled }}&replicaSet={{ .Values.mongo.rs }}{{- end }}{{- if (eq .Values.mongo.auth.enabled true) }}&authSource={{ .Values.mongo.auth.source }}{{- end }}{{- if .Values.mongo.connectTimeoutMS }}&connectTimeoutMS={{ .Values.mongo.connectTimeoutMS }}{{- end }}
         {{- end }}
+        {{- if .Values.mongo.keystore }}
+        keystore:
+        {{- toYaml .Values.mongo.keystore | nindent 10 }}
+        {{- end }}
+        {{- if .Values.mongo.truststore }}
+        truststore:
+        {{- toYaml .Values.mongo.truststore | nindent 10 }}
+        {{- end }}
       {{- else if (eq .Values.management.type "jdbc") }}
       jdbc:
         url: {{ .Values.jdbc.url }}

--- a/apim/3.x/tests/api/configmap_mongodb_test.yaml
+++ b/apim/3.x/tests/api/configmap_mongodb_test.yaml
@@ -77,3 +77,39 @@ tests:
                      *   sslEnabled: true\n
                      *   socketKeepAlive: true\n
                      *   uri: mongodb://username:password@graviteeio-apim-mongodb-replicaset:27117/dbname\\?&replicaSet=rs0&authSource=authSource&connectTimeoutMS=2000"
+  - it: Set mongo keystore attributes with provided values
+    template: api/api-configmap.yaml
+    set:
+      mongo:
+        keystore:
+          path: '/path/to/keystore.p12'
+          type: 'pkcs12'
+          password: 'keystorePassword'
+          keyPassword: 'keyPassword'
+    asserts:
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: " * mongodb:\n
+                    (.|\n)*\n
+                     *   keystore:\n
+                     *     keyPassword: keyPassword\n
+                     *     password: keystorePassword\n
+                     *     path: /path/to/keystore.p12\n
+                     *     type: pkcs12"
+  - it: Set mongo truststore attributes with provided values
+    template: api/api-configmap.yaml
+    set:
+      mongo:
+        truststore:
+          path: '/path/to/truststore.jks'
+          type: 'jks'
+          password: 'truststorePassword'
+    asserts:
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: " * mongodb:\n
+                    (.|\n)*\n
+                     *   truststore:\n
+                     *     password: truststorePassword\n
+                     *     path: /path/to/truststore.jks\n
+                     *     type: jks"

--- a/apim/3.x/tests/api/configmap_mongodb_test.yaml
+++ b/apim/3.x/tests/api/configmap_mongodb_test.yaml
@@ -1,0 +1,79 @@
+suite: Test Management API default configmap with MongoDB
+templates:
+  - "api/api-configmap.yaml"
+tests:
+  - it: Set common value and uri
+    template: api/api-configmap.yaml
+    set:
+      mongo:
+        sslEnabled: true
+        socketKeepAlive: true
+        uri: mongodb://mongo-mongodb-replicaset:27017/gravitee
+        auth:
+          enabled: true
+          username: username
+          password: password
+          authSource: authSource
+    asserts:
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: " * mongodb:\n
+                     *  sslEnabled: true\n
+                     *  socketKeepAlive: true\n
+                     *  uri: mongodb://mongo-mongodb-replicaset:27017/gravitee"
+  - it: Set common value and servers
+    template: api/api-configmap.yaml
+    set:
+      mongo:
+        sslEnabled: true
+        socketKeepAlive: true
+        servers: |
+          - host: mongo1
+            port: 27017
+          - host: mongo2
+            port: 27017
+        dbname: dbname
+        auth:
+          enabled: true
+          username: username
+          password: password
+          source: authSource
+    asserts:
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: " * mongodb:\n
+                     *   sslEnabled: true\n
+                     *   socketKeepAlive: true\n
+                     *   servers:\n
+                     *     - host: mongo1\n
+                     *       port: 27017\n
+                     *     - host: mongo2\n
+                     *       port: 27017\n
+                     *\n
+                     *   dbname: dbname\n
+                     *   username: username\n
+                     *   password: password\n
+                     *   authSource: authSource"
+  - it: Set common value and properties one by one
+    template: api/api-configmap.yaml
+    set:
+      mongo:
+        sslEnabled: true
+        socketKeepAlive: true
+        rsEnabled: true
+        dbhost: graviteeio-apim-mongodb-replicaset
+        dbname: dbname
+        dbport: 27117
+        connectTimeoutMS: 2000
+        auth:
+          enabled: true
+          username: username
+          password: password
+          source: authSource
+    asserts:
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: " * mongodb:\n
+                     *   sslEnabled: true\n
+                     *   socketKeepAlive: true\n
+                     *   uri: mongodb://username:password@graviteeio-apim-mongodb-replicaset:27117/dbname\\?&replicaSet=rs0&authSource=authSource&connectTimeoutMS=2000"

--- a/apim/3.x/tests/gateway/configmap_mongodb_test.yaml
+++ b/apim/3.x/tests/gateway/configmap_mongodb_test.yaml
@@ -1,0 +1,79 @@
+suite: Test Management API default configmap with MongoDB
+templates:
+  - "gateway/gateway-configmap.yaml"
+tests:
+  - it: Set common value and uri
+    template: gateway/gateway-configmap.yaml
+    set:
+      mongo:
+        sslEnabled: true
+        socketKeepAlive: true
+        uri: mongodb://mongo-mongodb-replicaset:27017/gravitee
+        auth:
+          enabled: true
+          username: username
+          password: password
+          authSource: authSource
+    asserts:
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: " * mongodb:\n
+                     *  sslEnabled: true\n
+                     *  socketKeepAlive: true\n
+                     *  uri: mongodb://mongo-mongodb-replicaset:27017/gravitee"
+  - it: Set common value and servers
+    template: gateway/gateway-configmap.yaml
+    set:
+      mongo:
+        sslEnabled: true
+        socketKeepAlive: true
+        servers: |
+          - host: mongo1
+            port: 27017
+          - host: mongo2
+            port: 27017
+        dbname: dbname
+        auth:
+          enabled: true
+          username: username
+          password: password
+          source: authSource
+    asserts:
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: " * mongodb:\n
+                     *   sslEnabled: true\n
+                     *   socketKeepAlive: true\n
+                     *   servers:\n
+                     *     - host: mongo1\n
+                     *       port: 27017\n
+                     *     - host: mongo2\n
+                     *       port: 27017\n
+                     *\n
+                     *   dbname: dbname\n
+                     *   username: username\n
+                     *   password: password\n
+                     *   authSource: authSource"
+  - it: Set common value and properties one by one
+    template: gateway/gateway-configmap.yaml
+    set:
+      mongo:
+        sslEnabled: true
+        socketKeepAlive: true
+        rsEnabled: true
+        dbhost: graviteeio-apim-mongodb-replicaset
+        dbname: dbname
+        dbport: 27117
+        connectTimeoutMS: 2000
+        auth:
+          enabled: true
+          username: username
+          password: password
+          source: authSource
+    asserts:
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: " * mongodb:\n
+                     *   sslEnabled: true\n
+                     *   socketKeepAlive: true\n
+                     *   uri: mongodb://username:password@graviteeio-apim-mongodb-replicaset:27117/dbname\\?&replicaSet=rs0&authSource=authSource&connectTimeoutMS=2000"

--- a/apim/3.x/tests/gateway/configmap_mongodb_test.yaml
+++ b/apim/3.x/tests/gateway/configmap_mongodb_test.yaml
@@ -77,3 +77,39 @@ tests:
                      *   sslEnabled: true\n
                      *   socketKeepAlive: true\n
                      *   uri: mongodb://username:password@graviteeio-apim-mongodb-replicaset:27117/dbname\\?&replicaSet=rs0&authSource=authSource&connectTimeoutMS=2000"
+  - it: Set mongo keystore attributes with provided values
+    template: gateway/gateway-configmap.yaml
+    set:
+      mongo:
+        keystore:
+          path: '/path/to/keystore.p12'
+          type: 'pkcs12'
+          password: 'keystorePassword'
+          keyPassword: 'keyPassword'
+    asserts:
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: " * mongodb:\n
+                    (.|\n)*\n
+                     *   keystore:\n
+                     *     keyPassword: keyPassword\n
+                     *     password: keystorePassword\n
+                     *     path: /path/to/keystore.p12\n
+                     *     type: pkcs12"
+  - it: Set mongo truststore attributes with provided values
+    template: gateway/gateway-configmap.yaml
+    set:
+      mongo:
+        truststore:
+          path: '/path/to/truststore.jks'
+          type: 'jks'
+          password: 'truststorePassword'
+    asserts:
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: " * mongodb:\n
+                    (.|\n)*\n
+                     *   truststore:\n
+                     *     password: truststorePassword\n
+                     *     path: /path/to/truststore.jks\n
+                     *     type: jks"


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7539

**Description**

Add support for `keystore` and `truststore` in MongoDB config
