### PR TITLE
feat(apim): add gravitee-license secret to apim's chart

### DIFF
--- a/apim/3.x/CHANGELOG.md
+++ b/apim/3.x/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 3.1.45
+
+- [X] Add the posibility of creating a secret with a gravitee-license for enterprise editions
 ### 3.1.44
 
 - [X] Add support for managed ServiceAccounts name provided by user

--- a/apim/3.x/Chart.yaml
+++ b/apim/3.x/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: apim3
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 3.1.44
+version: 3.1.45
 appVersion: 3.15.8
 description: Official Gravitee.io Helm chart for API Management 3.x
 home: https://gravitee.io

--- a/apim/3.x/templates/common/apim-license.yaml
+++ b/apim/3.x/templates/common/apim-license.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.enterpriseEdition.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gravitee-license
+data:
+  license.key: {{ .Values.enterpriseEdition.base64License }}
+{{- end -}}

--- a/apim/3.x/values.yaml
+++ b/apim/3.x/values.yaml
@@ -1241,3 +1241,9 @@ initContainers:
     runAsUser: 1001
     runAsNonRoot: true
   env: []
+
+# If enterprise edition is enabled, it creates a Secret named gravitee-license
+# The value of the license must be base64-encoded (required by k8s secrets)
+enterpriseEdition:
+  enabled: false
+  base64License: licenseContentEncodedInBase64


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/gravitee-cockpit/issues/2476

**Description**

To be able to fully automate apim-ee provisioning, the secret containing the license needs to be also created with the official chart

