### PR TITLE
Feat/apim add version on pods

### DIFF
--- a/ae/CHANGELOG.md
+++ b/ae/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to [Gravitee.io Alert Engine](https://github.com/gravitee-io/helm-charts/tree/master/ae) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 1.1.36
+
+- [X] Add version labels on pods
+
 ### 1.1.35
 
 - [X] Add support for managed ServiceAccounts name provided by user

--- a/ae/Chart.yaml
+++ b/ae/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: ae
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 1.1.35
+version: 1.1.36
 appVersion: 1.6.1
 description: Official Gravitee.io Helm chart for Alert Engine
 home: https://gravitee.io
@@ -20,4 +20,4 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/ae?modal=changelog
   artifacthub.io/changes: |
-    - Add support for managed ServiceAccounts name provided by user
+    - Add version labels on pods

--- a/ae/templates/engine-deployment.yaml
+++ b/ae/templates/engine-deployment.yaml
@@ -59,6 +59,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "gravitee.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Values.engine.image.tag | default .Chart.AppVersion | quote }}
         app.kubernetes.io/component: "{{ .Values.engine.name }}"
         {{- if .Values.engine.deployment.labels }}
         {{- range $key, $value := .Values.engine.deployment.labels }}

--- a/am/CHANGELOG.md
+++ b/am/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to [Gravitee.io Access Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/am/) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 1.0.43
+
+- [X] Add version labels on pods
+
 ### 1.0.42
 
 - [X] Add support for managed ServiceAccounts name provided by user

--- a/am/Chart.yaml
+++ b/am/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: am
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 1.0.42
+version: 1.0.43
 appVersion: 3.15.0
 description: Official Gravitee.io Helm chart for Access Management
 home: https://gravitee.io
@@ -23,4 +23,4 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/am?modal=changelog
   artifacthub.io/changes: |
-    - Add support for managed ServiceAccounts name provided by user
+    - Add version labels on pods

--- a/am/templates/api/api-deployment.yaml
+++ b/am/templates/api/api-deployment.yaml
@@ -53,6 +53,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "gravitee.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Values.api.image.tag | default .Chart.AppVersion | quote }}
         app.kubernetes.io/component: "{{ .Values.api.name }}"
         {{- if .Values.api.deployment.labels }}
         {{- range $key, $value := .Values.api.deployment.labels }}

--- a/am/templates/gateway/gateway-deployment.yaml
+++ b/am/templates/gateway/gateway-deployment.yaml
@@ -53,6 +53,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "gravitee.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Values.gateway.image.tag | default .Chart.AppVersion | quote }}
         app.kubernetes.io/component: "{{ .Values.gateway.name }}"
         {{- if .Values.gateway.deployment.labels }}
         {{- range $key, $value := .Values.gateway.deployment.labels }}

--- a/am/templates/ui/ui-deployment.yaml
+++ b/am/templates/ui/ui-deployment.yaml
@@ -49,6 +49,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "gravitee.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Values.ui.image.tag | default .Chart.AppVersion | quote }}
         app.kubernetes.io/component: "{{ .Values.ui.name }}"
         {{- if .Values.ui.deployment.labels }}
         {{- range $key, $value := .Values.ui.deployment.labels }}

--- a/apim/3.x/CHANGELOG.md
+++ b/apim/3.x/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 3.1.45
+
+- [X] Add version labels on pods
+
 ### 3.1.44
 
 - [X] Add support for managed ServiceAccounts name provided by user

--- a/apim/3.x/Chart.yaml
+++ b/apim/3.x/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: apim3
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 3.1.44
+version: 3.1.45
 appVersion: 3.15.8
 description: Official Gravitee.io Helm chart for API Management 3.x
 home: https://gravitee.io
@@ -20,4 +20,4 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/apim3?modal=changelog
   artifacthub.io/changes: |
-    - Add support for managed ServiceAccounts name provided by user
+    - Add version labels on pods

--- a/apim/3.x/templates/api/api-deployment.yaml
+++ b/apim/3.x/templates/api/api-deployment.yaml
@@ -53,6 +53,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "gravitee.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ default .Chart.AppVersion .Values.api.image.tag }}
         app.kubernetes.io/component: "{{ .Values.api.name }}"
         {{- if .Values.api.deployment.labels }}
         {{- range $key, $value := .Values.api.deployment.labels }}

--- a/apim/3.x/templates/gateway/gateway-deployment.yaml
+++ b/apim/3.x/templates/gateway/gateway-deployment.yaml
@@ -60,6 +60,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "gravitee.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ default .Chart.AppVersion .Values.gateway.image.tag }}
         app.kubernetes.io/component: "{{ .Values.gateway.name }}"
         {{- if .Values.gateway.deployment.labels }}
         {{- range $key, $value := .Values.gateway.deployment.labels }}

--- a/apim/3.x/templates/portal/portal-deployment.yaml
+++ b/apim/3.x/templates/portal/portal-deployment.yaml
@@ -46,6 +46,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "gravitee.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ default .Chart.AppVersion .Values.portal.image.tag }}
         app.kubernetes.io/component: "{{ .Values.portal.name }}"
         {{- if .Values.portal.deployment.labels }}
         {{- range $key, $value := .Values.portal.deployment.labels }}

--- a/apim/3.x/templates/ui/ui-deployment.yaml
+++ b/apim/3.x/templates/ui/ui-deployment.yaml
@@ -49,6 +49,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "gravitee.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ default .Chart.AppVersion .Values.ui.image.tag }}
         app.kubernetes.io/component: "{{ .Values.ui.name }}"
         {{- if .Values.ui.deployment.labels }}
         {{- range $key, $value := .Values.ui.deployment.labels }}

--- a/cockpit/CHANGELOG.md
+++ b/cockpit/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to [Gravitee.io Cockpit](https://github.com/gravitee-io/helm-charts/tree/master/cockpit) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 1.6.19
+
+- [X] Add version labels on pods
+
 ### 1.6.18
 
 - [X] Add support for managed ServiceAccounts name provided by user

--- a/cockpit/Chart.yaml
+++ b/cockpit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: cockpit
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 1.6.18
+version: 1.6.16
 appVersion: 3.16.0
 description: Official Gravitee.io Helm chart for Cockpit
 home: https://gravitee.io
@@ -21,5 +21,5 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/cockpit?modal=changelog
   artifacthub.io/changes: |
-    - Add support for managed ServiceAccounts name provided by user
+    - Add version labels on pods
     

--- a/cockpit/templates/api/api-deployment.yaml
+++ b/cockpit/templates/api/api-deployment.yaml
@@ -52,6 +52,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "gravitee.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Values.api.image.tag | default .Chart.AppVersion | quote }}
         app.kubernetes.io/component: "{{ .Values.api.name }}"
         {{- if .Values.api.deployment.labels }}
         {{- range $key, $value := .Values.api.deployment.labels }}

--- a/cockpit/templates/generator/generator-deployment.yaml
+++ b/cockpit/templates/generator/generator-deployment.yaml
@@ -47,6 +47,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "gravitee.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Values.generator.image.tag | default .Chart.AppVersion | quote }}
         app.kubernetes.io/component: "{{ .Values.generator.name }}"
         {{- if .Values.generator.deployment.labels }}
         {{- range $key, $value := .Values.generator.deployment.labels }}

--- a/cockpit/templates/ui/ui-deployment.yaml
+++ b/cockpit/templates/ui/ui-deployment.yaml
@@ -49,6 +49,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "gravitee.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Values.ui.image.tag | default .Chart.AppVersion | quote }}
         app.kubernetes.io/component: "{{ .Values.ui.name }}"
         {{- if .Values.ui.deployment.labels }}
         {{- range $key, $value := .Values.ui.deployment.labels }}

--- a/cockpit/tests/api/api-deployment_test.yaml
+++ b/cockpit/tests/api/api-deployment_test.yaml
@@ -76,6 +76,7 @@ tests:
               app.kubernetes.io/component: api
               app.kubernetes.io/instance: my-cockpit
               app.kubernetes.io/name: cockpit
+              app.kubernetes.io/version: 1.0.0-app
       - equal:
           path: spec.template.spec
           value:

--- a/cockpit/tests/generator/generator-deployment_test.yaml
+++ b/cockpit/tests/generator/generator-deployment_test.yaml
@@ -76,6 +76,7 @@ tests:
               app.kubernetes.io/component: swagger-generator
               app.kubernetes.io/instance: my-cockpit
               app.kubernetes.io/name: cockpit
+              app.kubernetes.io/version: 1.0.0-app
       - equal:
           path: spec.template.spec
           value:

--- a/cockpit/tests/ui/ui-deployment_test.yaml
+++ b/cockpit/tests/ui/ui-deployment_test.yaml
@@ -76,6 +76,7 @@ tests:
               app.kubernetes.io/component: ui
               app.kubernetes.io/instance: my-cockpit
               app.kubernetes.io/name: cockpit
+              app.kubernetes.io/version: 1.0.0-app
       - equal:
           path: spec.template.spec
           value:

--- a/designer/CHANGELOG.md
+++ b/designer/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to [Gravitee.io API Designer](https://github.com/gravitee-io/helm-charts/tree/master/designer) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 1.0.11
+
+- [X] Add version labels on pods
+- 
 ### 1.0.10
 
 - Ensure to run api designer api in production mode

--- a/designer/Chart.yaml
+++ b/designer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: designer
-version: 1.0.10
+version: 1.0.11
 appVersion: 1.31.4
 description: Official Gravitee.io Helm chart for API Designer
 home: https://gravitee.io
@@ -18,4 +18,4 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/designer?modal=changelog
   artifacthub.io/changes: |
-    - Ensure to run api designer api in production mode
+    - Add version labels on pods

--- a/designer/templates/api/api-deployment.yaml
+++ b/designer/templates/api/api-deployment.yaml
@@ -31,6 +31,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "gravitee.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion }}
         app.kubernetes.io/component: "{{ .Values.api.name }}"
     spec:
     {{- if .Values.api.nodeSelector }}

--- a/designer/templates/generator/generator-deployment.yaml
+++ b/designer/templates/generator/generator-deployment.yaml
@@ -31,6 +31,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "gravitee.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion }}
         app.kubernetes.io/component: "{{ .Values.generator.name }}"
     spec:
     {{- if .Values.generator.nodeSelector }}

--- a/designer/templates/ui/ui-deployment.yaml
+++ b/designer/templates/ui/ui-deployment.yaml
@@ -29,6 +29,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "gravitee.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion }}
         app.kubernetes.io/component: "{{ .Values.ui.name }}"
     spec:
     {{- if .Values.ui.nodeSelector }}


### PR DESCRIPTION
**Description**

This adds `app.kubernetes.io/version` label on pods specs, as it is a recommended label for every kubernetes resource.

(Originally requested by an Istio user, in order to fit Istio pod requirements https://istio.io/latest/docs/ops/deployment/requirements/#pod-requirements)