### PR TITLE
chore(apim): move 3.1.46 changes to 3.1.45 to avoid missing version number

### DIFF
--- a/apim/3.x/CHANGELOG.md
+++ b/apim/3.x/CHANGELOG.md
@@ -2,12 +2,9 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
-### 3.1.46
-
-- Add support for keystore and truststore in MongoDB configuration
-
 ### 3.1.45
 
+- [X] Add support for keystore and truststore in MongoDB configuration
 - [X] Add version labels on pods
 
 ### 3.1.44

--- a/apim/3.x/Chart.yaml
+++ b/apim/3.x/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: apim3
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 3.1.46
+version: 3.1.45
 appVersion: 3.15.8
 description: Official Gravitee.io Helm chart for API Management 3.x
 home: https://gravitee.io
@@ -21,3 +21,4 @@ annotations:
   # https://artifacthub.io/packages/helm/graviteeio/apim3?modal=changelog
   artifacthub.io/changes: |
     - Add support for keystore and truststore in MongoDB configuration
+    - Add version labels on pods


### PR DESCRIPTION
chore(apim): move 3.1.46 changes to 3.1.45 to avoid missing version number