### PR TITLE
feat: add networking.k8s.io/v1 ingress apiVersion to apim 1.x

### DIFF
--- a/apim/1.x/templates/_helpers.tpl
+++ b/apim/1.x/templates/_helpers.tpl
@@ -58,9 +58,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Return the apiVersion of ingress.
 */}}
 {{- define "ingress.apiVersion" -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
-    {{- print "networking.k8s.io/v1beta1" -}}
+{{- if semverCompare "<1.14-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "<1.19-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "networking.k8s.io/v1beta1" -}}
 {{- else -}}
-    {{- print "extensions/v1beta1" -}}
-{{- end -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end }}
 {{- end -}}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7925

**Description**

Include `networking.k8s.io/v1` ingress apiVersion in Gravitee APIM 1.X helm chart
