### PR TITLE
Authorize some special characters when fetching UI ingress path to compute management.url setting

### DIFF
--- a/apim/3.x/Chart.yaml
+++ b/apim/3.x/Chart.yaml
@@ -21,3 +21,4 @@ annotations:
   # https://artifacthub.io/packages/helm/graviteeio/apim3?modal=changelog
   artifacthub.io/changes: |
     - Add JSON logging support
+    - Accept some special characters in Management URL of API configmap. 

--- a/apim/3.x/templates/api/api-configmap.yaml
+++ b/apim/3.x/templates/api/api-configmap.yaml
@@ -37,7 +37,7 @@ data:
       {{- if .Values.management.url }}
       url: {{ .Values.management.url}}
       {{- else if .Values.ui.ingress.enabled }}
-      url: https://{{ index .Values.ui.ingress.hosts 0 }}{{ regexFind "/[a-zA-Z]+" .Values.ui.ingress.path }}/
+      url: https://{{ index .Values.ui.ingress.hosts 0 }}{{ regexFind "/[a-zA-Z-_.~]+" .Values.ui.ingress.path }}/
       {{- end }}
       type: {{ .Values.management.type | default "mongodb" }}
       {{- if or (eq .Values.management.type "mongodb") (kindIs "invalid" .Values.management.type) }}

--- a/apim/3.x/tests/api/configmap_test.yaml
+++ b/apim/3.x/tests/api/configmap_test.yaml
@@ -68,3 +68,29 @@ tests:
       - matchRegex:
           path: data.[gravitee.yml]
           pattern: "apiKey: myPendoKey"
+  - it: Set management.url with classical ingress path
+    template: api/api-configmap.yaml
+    set:
+      ui:
+        ingress:
+          enabled: true
+          path: /console
+          hosts:
+            - apim.example.com
+    asserts:
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "management:\n  url: https://apim.example.com/console/"
+  - it: Set management.url with a path containing authorized special characters
+    template: api/api-configmap.yaml
+    set:
+      ui:
+        ingress:
+          enabled: true
+          path: /mg.mt_-_ui~(/|$)(.*)
+          hosts:
+            - apim.example.com
+    asserts:
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "management:\n  url: https://apim.example.com/mg.mt_-_ui~/"


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8303

**Description**

authorize some special characters when fetching UI ingress path to compute management.url setting