### PR TITLE
chore(ae): bump chart to next version

### DIFF
--- a/ae/CHANGELOG.md
+++ b/ae/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to [Gravitee.io Alert Engine](https://github.com/gravitee-io/helm-charts/tree/master/ae) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 1.1.38
+
+- [X] Fix security context implementation
+
 ### 1.1.37
 
 - [X] Add support for autoscaling/v2

--- a/ae/Chart.yaml
+++ b/ae/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: ae
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 1.1.37
+version: 1.1.38
 appVersion: 1.6.4
 description: Official Gravitee.io Helm chart for Alert Engine
 home: https://gravitee.io
@@ -20,6 +20,5 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/ae?modal=changelog
   artifacthub.io/changes: |
-    - Add support for appProtocol to the services
-    - Add support for autoscaling/v2
-    - Add Bridge service to Management API
+    - Fix security context implementation
+


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8314

**Description**

This PR bumps AE charts to the next version

**Additional context**

PR merged: https://github.com/gravitee-io/helm-charts/pull/284
