### PR TITLE
Added attributes in values.yaml and modified flow in templates to eas…

### DIFF
--- a/ae/templates/engine-deployment.yaml
+++ b/ae/templates/engine-deployment.yaml
@@ -96,9 +96,7 @@ spec:
         - name: {{ template "gravitee.engine.fullname" . }}
           image: "{{ .Values.engine.image.repository }}:{{ default .Chart.AppVersion .Values.engine.image.tag }}"
           imagePullPolicy: {{ .Values.engine.image.pullPolicy }}
-          {{- if .Values.engine.runAsNonRoot }}
-          securityContext:  {{ toYaml .Values.engine.securityContext | nindent 12 }}
-          {{- end }}
+          securityContext:  {{include "common.container.securitycontext" (dict "runAsNonRoot" .Values.engine.runAsNonRoot "engineSecurityContext" .Values.engine.securityContext "openshift" .Values.openshift)| nindent 12}}
           ports:
             - name: {{ .Values.engine.service.internalPortName }}
               containerPort: {{ .Values.engine.service.internalPort }}

--- a/ae/templates/engine-ingress.yaml
+++ b/ae/templates/engine-ingress.yaml
@@ -17,7 +17,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   annotations:
     {{- if .Values.engine.ingress.annotations }}
-    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.engine.ingress.annotations "ingressClassName" .Values.engine.ingress.ingressClassName "context" $) | nindent 4 }}
+    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.engine.ingress.annotations "ingressClassName" .Values.engine.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
     {{- end }}
 spec:
   {{- if and .Values.engine.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}

--- a/ae/templates/engine-technical-ingress.yaml
+++ b/ae/templates/engine-technical-ingress.yaml
@@ -17,7 +17,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   annotations:
     {{- if .Values.engine.services.core.ingress.annotations }}
-    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.engine.services.core.ingress.annotations "ingressClassName" .Values.engine.services.core.ingress.ingressClassName "context" $) | nindent 4 }}
+    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.engine.services.core.ingress.annotations "ingressClassName" .Values.engine.services.core.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
     {{- end }}
 spec:
   {{- if and .Values.engine.services.core.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}

--- a/ae/tests/deployment_openshift_test.yaml
+++ b/ae/tests/deployment_openshift_test.yaml
@@ -1,0 +1,77 @@
+suite: Test Alert Engine OpenShift deployment
+templates:
+  - "engine-deployment.yaml"
+  - "engine-configmap.yaml"
+tests:
+  - it: Verify that the security context from OpenShift attribute is used
+    template: engine-deployment.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    #values:
+    #  - ./values/staging.yaml
+    set:
+      openshift:
+        enabled: true
+        securityContext:
+          runAsUser: 9999
+          runAsGroup: 9998
+          runAsNonRoot: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: graviteeio/ae-engine:1.0.0-app
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 9998
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 9999
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: false
+  - it: Verify that the security context from the api attribute is used in case openshift is disabled
+    template: engine-deployment.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    #values:
+    #  - ./values/staging.yaml
+    set:
+      openshift:
+        enabled: false
+        securityContext:
+          runAsUser: 9999
+          runAsGroup: 9998
+          runAsNonRoot: false
+      engine:
+        runAsNonRoot: true
+        securityContext:
+          runAsUser: 8888
+          runAsGroup: 8887
+          runAsNonRoot: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: graviteeio/ae-engine:1.0.0-app
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 8887
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 8888
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true

--- a/ae/tests/deployment_test.yaml
+++ b/ae/tests/deployment_test.yaml
@@ -89,6 +89,7 @@ tests:
                 periodSeconds: 5
                 tcpSocket:
                   port: http
+              securityContext: null
               startupProbe:
                 failureThreshold: 20
                 initialDelaySeconds: 30

--- a/ae/tests/ingress_openshift_test.yaml
+++ b/ae/tests/ingress_openshift_test.yaml
@@ -1,0 +1,81 @@
+suite: Test Engine Ingress for OpenShift
+templates:
+  - "engine-ingress.yaml"
+tests:
+  - it: Check that the annotation kubernetes.io/ingress.class is removed if OpenShift is enabled
+    set:
+      openshift:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: edge
+  - it: Check that the annotation route.openshift.io/termination is using the value from openshift 
+    set:
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is enabled and generateRoute is set to false
+    set:
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: false
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is disabled and no annotations are added from openshift ingress attribute
+    set:
+      openshift:
+        enabled: false
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - isNull:
+          path: metadata.annotations.[route.openshift.io/termination]

--- a/ae/tests/ingress_technical_openshift_test.yaml
+++ b/ae/tests/ingress_technical_openshift_test.yaml
@@ -1,0 +1,138 @@
+suite: Test Engine - Technical API Ingress for OpenShift
+templates:
+  - "engine-technical-ingress.yaml"
+tests:
+  - it: Check that the annotation kubernetes.io/ingress.class is removed if OpenShift is enabled
+    set:
+    #.Values.api.http.services.core.ingress.annotations
+      engine:
+        services:
+          core:
+            ingress:
+              enabled: true
+              annotations:
+                kubernetes.io/ingress.class: nginx
+                nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: true        
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: edge
+  - it: Check that the annotation route.openshift.io/termination is using the value from openshift 
+    set:
+      engine:
+        services:
+          core:
+            ingress:
+              enabled: true
+              annotations:
+                kubernetes.io/ingress.class: nginx
+                nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is enabled and generateRoute is set to false
+    set:
+      engine:
+        services:
+          core:
+            ingress:
+              enabled: true
+              annotations:
+                kubernetes.io/ingress.class: nginx
+                nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: false
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is disabled and no annotations are added from openshift ingress attribute
+    set:
+      engine:
+        services:
+          core:
+            ingress:
+              enabled: true
+              annotations:
+                kubernetes.io/ingress.class: nginx
+                nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: false
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - isNull:
+          path: metadata.annotations.[route.openshift.io/termination]
+  - it: Check that the annotation kubernetes.io/ingress.class is removed if OpenShift is enabled, even if the value is not nginx
+    set:
+      engine:
+        services:
+          core:
+            ingress:
+              enabled: true
+              annotations:
+                kubernetes.io/ingress.class: traefik
+                nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: true        
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: edge

--- a/ae/values.yaml
+++ b/ae/values.yaml
@@ -228,3 +228,14 @@ engine:
       enabled: false
       prometheus:
         enabled: true
+
+openshift:
+  enabled: false
+  securityContext:
+    runAsUser: null
+    runAsGroup: null
+    runAsNonRoot: true
+  ingress:
+    generateRoute: true
+    annotations:
+      route.openshift.io/termination: "edge"

--- a/am/templates/api/api-deployment.yaml
+++ b/am/templates/api/api-deployment.yaml
@@ -84,7 +84,7 @@ spec:
       {{- if .Values.api.additionalPlugins -}}
         {{- $plugins = concat $plugins .Values.api.additionalPlugins -}}
       {{- end -}}
-      {{- $pluginParams := dict "plugins" $plugins "jdbcDrivers" .Values.jdbc.drivers "securityContext" .Values.api.securityContext "appName" "graviteeio-am-management-api" "initContainers" $initContainers -}}
+      {{- $pluginParams := dict "plugins" $plugins "jdbcDrivers" .Values.jdbc.drivers "securityContext" .Values.api.securityContext "appName" "graviteeio-am-management-api" "initContainers" $initContainers "openshift" .Values.openshift -}}
       {{- if or .Values.api.extraInitContainers $plugins .Values.jdbc.drivers }}
       initContainers:
         {{- if and .Values.jdbc.drivers (eq .Values.management.type "jdbc") }}
@@ -99,7 +99,7 @@ spec:
         - name: {{ template "gravitee.api.fullname" . }}
           image: "{{ .Values.api.image.repository }}:{{ default .Chart.AppVersion .Values.api.image.tag }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
-          securityContext: {{ toYaml ( .Values.api.securityContext | default .Values.api.deployment.securityContext ) | nindent 12 }}
+          securityContext: {{include "common.container.securitycontext" (dict "currentSecurityContext" .Values.api.securityContext "defaultSecurityContext" .Values.api.deployment.securityContext "openshift" .Values.openshift)| nindent 12}}
           ports:
             - name: {{ .Values.api.service.internalPortName }}
               containerPort: {{ .Values.api.service.internalPort }}

--- a/am/templates/api/api-ingress.yaml
+++ b/am/templates/api/api-ingress.yaml
@@ -17,7 +17,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   annotations:
     {{- if .Values.api.ingress.annotations }}
-    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.api.ingress.annotations "ingressClassName" .Values.api.ingress.ingressClassName "context" $) | nindent 4 }}
+    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.api.ingress.annotations "ingressClassName" .Values.api.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
     {{- end }}
 spec:
   {{- if and .Values.api.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}

--- a/am/templates/api/api-technical-ingress.yaml
+++ b/am/templates/api/api-technical-ingress.yaml
@@ -17,7 +17,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   annotations:
     {{- if .Values.api.http.services.core.ingress.annotations }}
-    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.api.http.services.core.ingress.annotations "ingressClassName" .Values.api.http.services.core.ingress.ingressClassName "context" $) | nindent 4 }}
+    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.api.http.services.core.ingress.annotations "ingressClassName" .Values.api.http.services.core.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
     {{- end }}
 spec:
   {{- if and .Values.api.http.services.core.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}

--- a/am/templates/gateway/gateway-deployment.yaml
+++ b/am/templates/gateway/gateway-deployment.yaml
@@ -84,7 +84,7 @@ spec:
       {{- if .Values.gateway.additionalPlugins -}}
         {{- $plugins = concat $plugins .Values.gateway.additionalPlugins -}}
       {{- end -}}
-      {{- $pluginParams := dict "plugins" $plugins "jdbcDrivers" .Values.jdbc.drivers "securityContext" .Values.api.securityContext "appName" "graviteeio-am-gateway" "initContainers" $initContainers -}}
+      {{- $pluginParams := dict "plugins" $plugins "jdbcDrivers" .Values.jdbc.drivers "securityContext" .Values.api.securityContext "appName" "graviteeio-am-gateway" "initContainers" $initContainers  "openshift" .Values.openshift -}}
       {{- if or .Values.gateway.extraInitContainers $plugins .Values.jdbc.drivers }}
       initContainers:
         {{- if and .Values.jdbc.drivers (eq .Values.management.type "jdbc") }}
@@ -99,7 +99,7 @@ spec:
         - name: {{ template "gravitee.gateway.fullname" . }}
           image: "{{ .Values.gateway.image.repository }}:{{ default .Chart.AppVersion .Values.gateway.image.tag }}"
           imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
-          securityContext: {{ toYaml ( .Values.gateway.securityContext | default .Values.gateway.deployment.securityContext ) | nindent 12 }}
+          securityContext: {{include "common.container.securitycontext" (dict "currentSecurityContext" .Values.gateway.securityContext "defaultSecurityContext" .Values.gateway.deployment.securityContext "openshift" .Values.openshift)| nindent 12}}
           ports:
             - name: {{ .Values.gateway.service.internalPortName }}
               containerPort: {{ .Values.gateway.service.internalPort }}

--- a/am/templates/gateway/gateway-ingress.yaml
+++ b/am/templates/gateway/gateway-ingress.yaml
@@ -17,7 +17,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   annotations:
     {{- if .Values.gateway.ingress.annotations }}
-    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.gateway.ingress.annotations "ingressClassName" .Values.gateway.ingress.ingressClassName "context" $) | nindent 4 }}
+    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.gateway.ingress.annotations "ingressClassName" .Values.gateway.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
     {{- end }}
 spec:
   {{- if and .Values.gateway.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}

--- a/am/templates/gateway/gateway-technical-ingress.yaml
+++ b/am/templates/gateway/gateway-technical-ingress.yaml
@@ -17,7 +17,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   annotations:
     {{- if .Values.gateway.services.core.ingress.annotations }}
-    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.gateway.services.core.ingress.annotations "ingressClassName" .Values.gateway.services.core.ingress.ingressClassName "context" $) | nindent 4 }}
+    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.gateway.services.core.ingress.annotations "ingressClassName" .Values.gateway.services.core.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
     {{- end }}
 spec:
   {{- if and .Values.gateway.services.core.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}

--- a/am/templates/ui/ui-deployment.yaml
+++ b/am/templates/ui/ui-deployment.yaml
@@ -83,7 +83,7 @@ spec:
         - name: {{ template "gravitee.ui.fullname" . }}
           image: "{{ .Values.ui.image.repository }}:{{ default .Chart.AppVersion .Values.ui.image.tag }}"
           imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
-          securityContext: {{ toYaml ( .Values.ui.securityContext | default .Values.ui.deployment.securityContext ) | nindent 12 }}
+          securityContext: {{include "common.container.securitycontext" (dict "currentSecurityContext" .Values.ui.securityContext "defaultSecurityContext" .Values.ui.deployment.securityContext "openshift" .Values.openshift)| nindent 12}}
           env:
             - name: MGMT_API_URL
               value: "https://{{index .Values.api.ingress.hosts 0 }}"

--- a/am/templates/ui/ui-ingress.yaml
+++ b/am/templates/ui/ui-ingress.yaml
@@ -17,7 +17,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   annotations:
     {{- if .Values.ui.ingress.annotations }}
-    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.ui.ingress.annotations "ingressClassName" .Values.ui.ingress.ingressClassName "context" $) | nindent 4 }}
+    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.ui.ingress.annotations "ingressClassName" .Values.ui.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
     {{- end }}
 spec:
   {{- if and .Values.ui.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}

--- a/am/tests/api/deployment_openshift_test.yaml
+++ b/am/tests/api/deployment_openshift_test.yaml
@@ -1,0 +1,170 @@
+suite: Test Management API OpenShift deployment
+templates:
+  - "api/api-deployment.yaml"
+  - "api/api-configmap.yaml"  
+tests:
+  - it: Verify that the security context from OpenShift attribute is used
+    template: api/api-deployment.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    #values:
+    #  - ./values/staging.yaml
+    set:
+      management:
+        type: jdbc
+      jdbc:
+        driver: postgresql
+      openshift:
+        enabled: true
+        securityContext:
+          runAsUser: 9999
+          runAsGroup: 9998
+          runAsNonRoot: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: graviteeio/am-management-api:1.0.0-app
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 9998
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 9999
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: false
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsGroup
+          value: 9998
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+          value: 9999
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: false
+  - it: Verify that the security context from the api attribute is used in case openshift is disabled
+    template: api/api-deployment.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    #values:
+    #  - ./values/staging.yaml
+    set:
+      management:
+        type: jdbc
+      jdbc:
+        driver: postgresql
+      openshift:
+        enabled: false
+        securityContext:
+          runAsUser: 9999
+          runAsGroup: 9998
+          runAsNonRoot: false
+      api:
+        securityContext:
+          runAsUser: 8888
+          runAsGroup: 8887
+          runAsNonRoot: true
+        deployment:
+          securityContext:
+            runAsUser: 7777
+            runAsGroup: 7776
+            runAsNonRoot: true
+      initContainers:
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 6666
+          runAsGroup: 6665
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: graviteeio/am-management-api:1.0.0-app
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 8887
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 8888
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsGroup
+          value: 6665
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+          value: 6666
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: true
+  - it: Verify that the security context from the api deployment attribute is used in case openshift is disabled and the api security content is null
+    template: api/api-deployment.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    #values:
+    #  - ./values/staging.yaml
+    set:
+      management:
+        type: jdbc
+      jdbc:
+        driver: postgresql
+      openshift:
+        enabled: false
+        securityContext:
+          runAsUser: 9999
+          runAsGroup: 9998
+          runAsNonRoot: false
+      api:
+        securityContext: null
+        deployment:
+          securityContext:
+            runAsUser: 7777
+            runAsGroup: 7776
+            runAsNonRoot: true
+      initContainers:
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 6666
+          runAsGroup: 6665
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: graviteeio/am-management-api:1.0.0-app
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 7776
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 7777
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsGroup
+          value: 6665
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+          value: 6666
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: true

--- a/am/tests/api/ingress_openshift_test.yaml
+++ b/am/tests/api/ingress_openshift_test.yaml
@@ -1,0 +1,81 @@
+suite: Test Management API Ingress for OpenShift
+templates:
+  - "api/api-ingress.yaml"
+tests:
+  - it: Check that the annotation kubernetes.io/ingress.class is removed if OpenShift is enabled
+    set:
+      openshift:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: edge
+  - it: Check that the annotation route.openshift.io/termination is using the value from openshift 
+    set:
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is enabled and generateRoute is set to false
+    set:
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: false
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is disabled and no annotations are added from openshift ingress attribute
+    set:
+      openshift:
+        enabled: false
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - isNull:
+          path: metadata.annotations.[route.openshift.io/termination]

--- a/am/tests/api/ingress_technical_openshift_test.yaml
+++ b/am/tests/api/ingress_technical_openshift_test.yaml
@@ -1,0 +1,144 @@
+suite: Test Management API - Technical API Ingress for OpenShift
+templates:
+  - "api/api-technical-ingress.yaml"
+tests:
+  - it: Check that the annotation kubernetes.io/ingress.class is removed if OpenShift is enabled
+    set:
+    #.Values.api.http.services.core.ingress.annotations
+      api:
+        http:
+          services:
+            core:
+              ingress:
+                enabled: true
+                annotations:
+                  kubernetes.io/ingress.class: nginx
+                  nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: true        
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: edge
+  - it: Check that the annotation route.openshift.io/termination is using the value from openshift 
+    set:
+      api:
+        http:
+          services:
+            core:
+              ingress:
+                enabled: true
+                annotations:
+                  kubernetes.io/ingress.class: nginx
+                  nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is enabled and generateRoute is set to false
+    set:
+      api:
+        http:
+          services:
+            core:
+              ingress:
+                enabled: true
+                annotations:
+                  kubernetes.io/ingress.class: nginx
+                  nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: false
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is disabled and no annotations are added from openshift ingress attribute
+    set:
+      api:
+        http:
+          services:
+            core:
+              ingress:
+                enabled: true
+                annotations:
+                  kubernetes.io/ingress.class: nginx
+                  nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: false
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - isNull:
+          path: metadata.annotations.[route.openshift.io/termination]
+  - it: Check that the annotation kubernetes.io/ingress.class is removed if OpenShift is enabled, even if the value is not nginx
+    set:
+    #.Values.api.http.services.core.ingress.annotations
+      api:
+        http:
+          services:
+            core:
+              ingress:
+                enabled: true
+                annotations:
+                  kubernetes.io/ingress.class: traefik
+                  nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: true        
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: edge

--- a/am/tests/gateway/deployment_openshift_test.yaml
+++ b/am/tests/gateway/deployment_openshift_test.yaml
@@ -1,0 +1,170 @@
+suite: Test Management gateway OpenShift deployment
+templates:
+  - "gateway/gateway-deployment.yaml"
+  - "gateway/gateway-configmap.yaml"
+tests:
+  - it: Verify that the security context from OpenShift attribute is used
+    template: gateway/gateway-deployment.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    #values:
+    #  - ./values/staging.yaml
+    set:
+      management:
+        type: jdbc
+      jdbc:
+        driver: postgresql
+      openshift:
+        enabled: true
+        securityContext:
+          runAsUser: 9999
+          runAsGroup: 9998
+          runAsNonRoot: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: graviteeio/am-gateway:1.0.0-app
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 9998
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 9999
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: false
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsGroup
+          value: 9998
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+          value: 9999
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: false
+  - it: Verify that the security context from the api attribute is used in case openshift is disabled
+    template: gateway/gateway-deployment.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    #values:
+    #  - ./values/staging.yaml
+    set:
+      management:
+        type: jdbc
+      jdbc:
+        driver: postgresql
+      openshift:
+        enabled: false
+        securityContext:
+          runAsUser: 9999
+          runAsGroup: 9998
+          runAsNonRoot: false
+      gateway:
+        securityContext:
+          runAsUser: 8888
+          runAsGroup: 8887
+          runAsNonRoot: true
+        deployment:
+          securityContext:
+            runAsUser: 7777
+            runAsGroup: 7776
+            runAsNonRoot: true
+      initContainers:
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 6666
+          runAsGroup: 6665
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: graviteeio/am-gateway:1.0.0-app
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 8887
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 8888
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsGroup
+          value: 6665
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+          value: 6666
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: true
+  - it: Verify that the security context from the api deployment attribute is used in case openshift is disabled and the api security content is null
+    template: gateway/gateway-deployment.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    #values:
+    #  - ./values/staging.yaml
+    set:
+      management:
+        type: jdbc
+      jdbc:
+        driver: postgresql
+      openshift:
+        enabled: false
+        securityContext:
+          runAsUser: 9999
+          runAsGroup: 9998
+          runAsNonRoot: false
+      gateway:
+        securityContext: null
+        deployment:
+          securityContext:
+            runAsUser: 7777
+            runAsGroup: 7776
+            runAsNonRoot: true
+      initContainers:
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 6666
+          runAsGroup: 6665
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: graviteeio/am-gateway:1.0.0-app
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 7776
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 7777
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsGroup
+          value: 6665
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+          value: 6666
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: true

--- a/am/tests/gateway/ingress_openshift_test.yaml
+++ b/am/tests/gateway/ingress_openshift_test.yaml
@@ -1,0 +1,81 @@
+suite: Test API Gateway Ingress for OpenShift
+templates:
+  - "gateway/gateway-ingress.yaml"
+tests:
+  - it: Check that the annotation kubernetes.io/ingress.class is removed if OpenShift is enabled
+    set:
+      openshift:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: edge
+  - it: Check that the annotation route.openshift.io/termination is using the value from openshift 
+    set:
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is enabled and generateRoute is set to false
+    set:
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: false
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is disabled and no annotations are added from openshift ingress attribute
+    set:
+      openshift:
+        enabled: false
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - isNull:
+          path: metadata.annotations.[route.openshift.io/termination]

--- a/am/tests/gateway/ingress_technical_openshift_test.yaml
+++ b/am/tests/gateway/ingress_technical_openshift_test.yaml
@@ -1,0 +1,137 @@
+suite: Test API Gateway - Technical API Ingress for OpenShift
+templates:
+  - "gateway/gateway-technical-ingress.yaml"
+tests:
+  - it: Check that the annotation kubernetes.io/ingress.class is removed if OpenShift is enabled
+    set:
+      gateway:
+        services:
+          core:
+            ingress:
+              enabled: true
+              annotations:
+                kubernetes.io/ingress.class: nginx
+                nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: edge
+  - it: Check that the annotation route.openshift.io/termination is using the value from openshift 
+    set:
+      gateway:
+        services:
+          core:
+            ingress:
+              enabled: true
+              annotations:
+                kubernetes.io/ingress.class: nginx
+                nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is enabled and generateRoute is set to false
+    set:
+      gateway:
+        services:
+          core:
+            ingress:
+              enabled: true
+              annotations:
+                kubernetes.io/ingress.class: nginx
+                nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: false
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is disabled and no annotations are added from openshift ingress attribute
+    set:
+      gateway:
+        services:
+          core:
+            ingress:
+              enabled: true
+              annotations:
+                kubernetes.io/ingress.class: nginx
+                nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: false
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - isNull:
+          path: metadata.annotations.[route.openshift.io/termination]
+  - it: Check that the annotation kubernetes.io/ingress.class is removed if OpenShift is enabled, even if the value is not nginx
+    set:
+      gateway:
+        services:
+          core:
+            ingress:
+              enabled: true
+              annotations:
+                kubernetes.io/ingress.class: traefik
+                nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: edge

--- a/am/tests/ui/deployment_openshift_test.yaml
+++ b/am/tests/ui/deployment_openshift_test.yaml
@@ -1,0 +1,121 @@
+suite: Test Management UI OpenShift deployment
+templates:
+  - "ui/ui-deployment.yaml"
+  - "ui/ui-configmap.yaml"
+tests:
+  - it: Verify that the security context from OpenShift attribute is used
+    template: ui/ui-deployment.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    #values:
+    #  - ./values/staging.yaml
+    set:
+      openshift:
+        enabled: true
+        securityContext:
+          runAsUser: 9999
+          runAsGroup: 9998
+          runAsNonRoot: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: graviteeio/am-management-ui:1.0.0-app
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 9998
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 9999
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: false
+  - it: Verify that the security context from the api attribute is used in case openshift is disabled
+    template: ui/ui-deployment.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    #values:
+    #  - ./values/staging.yaml
+    set:
+      openshift:
+        enabled: false
+        securityContext:
+          runAsUser: 9999
+          runAsGroup: 9998
+          runAsNonRoot: false
+      ui:
+        securityContext:
+          runAsUser: 8888
+          runAsGroup: 8887
+          runAsNonRoot: true
+        deployment:
+          securityContext:
+            runAsUser: 7777
+            runAsGroup: 7776
+            runAsNonRoot: true          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: graviteeio/am-management-ui:1.0.0-app
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 8887
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 8888
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+  - it: Verify that the security context from the api deployment attribute is used in case openshift is disabled and the api security content is null
+    template: ui/ui-deployment.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    #values:
+    #  - ./values/staging.yaml
+    set:
+      openshift:
+        enabled: false
+        securityContext:
+          runAsUser: 9999
+          runAsGroup: 9998
+          runAsNonRoot: false
+      ui:
+        securityContext: null
+        deployment:
+          securityContext:
+            runAsUser: 7777
+            runAsGroup: 7776
+            runAsNonRoot: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: graviteeio/am-management-ui:1.0.0-app
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 7776
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 7777
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true          

--- a/am/tests/ui/ingress_openshift_test.yaml
+++ b/am/tests/ui/ingress_openshift_test.yaml
@@ -1,0 +1,81 @@
+suite: Test Console Ingress for OpenShift
+templates:
+  - "ui/ui-ingress.yaml"
+tests:
+  - it: Check that the annotation kubernetes.io/ingress.class is removed if OpenShift is enabled
+    set:
+      openshift:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: edge
+  - it: Check that the annotation route.openshift.io/termination is using the value from openshift 
+    set:
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is enabled and generateRoute is set to false
+    set:
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: false
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is disabled and no annotations are added from openshift ingress attribute
+    set:
+      openshift:
+        enabled: false
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - isNull:
+          path: metadata.annotations.[route.openshift.io/termination]

--- a/am/values.yaml
+++ b/am/values.yaml
@@ -786,3 +786,14 @@ initContainers:
     runAsUser: 1001
     runAsNonRoot: true
   env: []
+
+openshift:
+  enabled: false
+  securityContext:
+    runAsUser: null
+    runAsGroup: null
+    runAsNonRoot: true
+  ingress:
+    generateRoute: true
+    annotations:
+      route.openshift.io/termination: "edge"

--- a/apim/3.x/templates/api/api-bridge-ingress.yaml
+++ b/apim/3.x/templates/api/api-bridge-ingress.yaml
@@ -18,7 +18,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   annotations:
     {{- if .Values.api.services.bridge.ingress.annotations }}
-    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.api.services.bridge.ingress.annotations "ingressClassName" .Values.api.services.bridge.ingress.ingressClassName "context" $) | nindent 4 }}
+    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.api.services.bridge.ingress.annotations "ingressClassName" .Values.api.services.bridge.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
     {{- end }}
 spec:
   {{- if and .Values.api.services.bridge.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}

--- a/apim/3.x/templates/api/api-deployment.yaml
+++ b/apim/3.x/templates/api/api-deployment.yaml
@@ -90,7 +90,7 @@ spec:
       initContainers:
         {{- if and .Values.jdbc.driver (eq .Values.management.type "jdbc") }}
         - name: get-repository-jdbc-ext
-          {{- toYaml .Values.initContainers | nindent 10 }}
+          {{- include "common.initcontainer.securitycontext" (dict "initContainers" .Values.initContainers "openshift" .Values.openshift) | indent 8}}
           command: ['sh', '-c', "mkdir -p /tmp/plugins-ext && cd /tmp/plugins-ext && wget  {{ .Values.jdbc.driver }}"]
           volumeMounts:
             - name: graviteeio-apim-repository-jdbc-ext
@@ -105,7 +105,7 @@ spec:
         - name: {{ template "gravitee.api.fullname" . }}
           image: "{{ .Values.api.image.repository }}:{{ default .Chart.AppVersion .Values.api.image.tag }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
-          securityContext: {{ toYaml ( .Values.api.securityContext | default .Values.api.deployment.securityContext ) | nindent 12 }}
+          securityContext: {{include "common.container.securitycontext" (dict "currentSecurityContext" .Values.api.securityContext "defaultSecurityContext" .Values.api.deployment.securityContext "openshift" .Values.openshift)| nindent 12}}
           ports:
             - name: {{ .Values.api.service.internalPortName }}
               containerPort: {{ .Values.api.service.internalPort }}

--- a/apim/3.x/templates/api/api-ingress-management.yaml
+++ b/apim/3.x/templates/api/api-ingress-management.yaml
@@ -17,7 +17,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   annotations:
     {{- if .Values.api.ingress.management.annotations }}
-    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.api.ingress.management.annotations "ingressClassName" .Values.api.ingress.management.ingressClassName "context" $) | nindent 4 }}
+    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.api.ingress.management.annotations "ingressClassName" .Values.api.ingress.management.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
     {{- end }}
 spec:
   {{- if and .Values.api.ingress.management.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}

--- a/apim/3.x/templates/api/api-ingress-portal.yaml
+++ b/apim/3.x/templates/api/api-ingress-portal.yaml
@@ -17,7 +17,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   annotations:
     {{- if .Values.api.ingress.portal.annotations }}
-    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.api.ingress.portal.annotations "ingressClassName" .Values.api.ingress.portal.ingressClassName "context" $) | nindent 4 }}
+    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.api.ingress.portal.annotations "ingressClassName" .Values.api.ingress.portal.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
     {{- end }}
 spec:
   {{- if and .Values.api.ingress.portal.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}

--- a/apim/3.x/templates/api/api-technical-ingress.yaml
+++ b/apim/3.x/templates/api/api-technical-ingress.yaml
@@ -17,7 +17,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   annotations:
     {{- if .Values.api.http.services.core.ingress.annotations }}
-    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.api.http.services.core.ingress.annotations "ingressClassName" .Values.api.http.services.core.ingress.ingressClassName "context" $) | nindent 4 }}
+    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.api.http.services.core.ingress.annotations "ingressClassName" .Values.api.http.services.core.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
     {{- end }}
 spec:
   {{- if and .Values.api.http.services.core.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}

--- a/apim/3.x/templates/gateway/gateway-bridge-ingress.yaml
+++ b/apim/3.x/templates/gateway/gateway-bridge-ingress.yaml
@@ -18,7 +18,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   annotations:
     {{- if .Values.gateway.services.bridge.ingress.annotations }}
-    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.gateway.services.bridge.ingress.annotations "ingressClassName" .Values.gateway.services.bridge.ingress.ingressClassName "context" $) | nindent 4 }}
+    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.gateway.services.bridge.ingress.annotations "ingressClassName" .Values.gateway.services.bridge.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
     {{- end }}
 spec:
   {{- if and .Values.gateway.services.bridge.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}

--- a/apim/3.x/templates/gateway/gateway-deployment.yaml
+++ b/apim/3.x/templates/gateway/gateway-deployment.yaml
@@ -104,7 +104,7 @@ spec:
       initContainers:
         {{- if and .Values.jdbc.driver (eq .Values.management.type "jdbc") }}
         - name: get-repository-jdbc-ext
-          {{- toYaml .Values.initContainers | nindent 10 }}
+          {{- include "common.initcontainer.securitycontext" (dict "initContainers" .Values.initContainers "openshift" .Values.openshift) | indent 8}}
           command: ['sh', '-c', "mkdir -p /tmp/plugins-ext && cd /tmp/plugins-ext && wget  {{ .Values.jdbc.driver }}"]
           volumeMounts:
             - name: graviteeio-apim-repository-jdbc-ext
@@ -123,7 +123,7 @@ spec:
         - name: {{ template "gravitee.gateway.fullname" . }}
           image: "{{ .Values.gateway.image.repository }}:{{ default .Chart.AppVersion .Values.gateway.image.tag }}"
           imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
-          securityContext: {{ toYaml ( .Values.gateway.securityContext | default .Values.gateway.deployment.securityContext ) | nindent 12 }}
+          securityContext: {{include "common.container.securitycontext" (dict "currentSecurityContext" .Values.gateway.securityContext "defaultSecurityContext" .Values.gateway.deployment.securityContext "openshift" .Values.openshift)| nindent 12}}
           ports:
             - name: {{ .Values.gateway.service.internalPortName }}
               containerPort: {{ .Values.gateway.service.internalPort }}

--- a/apim/3.x/templates/gateway/gateway-ingress.yaml
+++ b/apim/3.x/templates/gateway/gateway-ingress.yaml
@@ -17,7 +17,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   annotations:
     {{- if .Values.gateway.ingress.annotations }}
-    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.gateway.ingress.annotations "ingressClassName" .Values.gateway.ingress.ingressClassName "context" $) | nindent 4 }}
+    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.gateway.ingress.annotations "ingressClassName" .Values.gateway.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
     {{- end }}
 spec:
   {{- if and .Values.gateway.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}

--- a/apim/3.x/templates/gateway/gateway-technical-ingress.yaml
+++ b/apim/3.x/templates/gateway/gateway-technical-ingress.yaml
@@ -17,7 +17,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   annotations:
     {{- if .Values.gateway.services.core.ingress.annotations }}
-    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.gateway.services.core.ingress.annotations "ingressClassName" .Values.gateway.services.core.ingress.ingressClassName "context" $) | nindent 4 }}
+    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.gateway.services.core.ingress.annotations "ingressClassName" .Values.gateway.services.core.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
     {{- end }}
 spec:
   {{- if and .Values.gateway.services.core.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}
@@ -41,7 +41,7 @@ spec:
           servicePort: {{ $serviceAPIPort }}
           {{- end -}}
   {{- end -}}
-  {{- if .Values.gateway.services.core.ingress.tls }}
+  {{- if .Values.gateway.services.core.ingress.tls }}  
   tls:
 {{ toYaml .Values.gateway.services.core.ingress.tls | indent 4 }}
   {{- end -}}

--- a/apim/3.x/templates/portal/portal-deployment.yaml
+++ b/apim/3.x/templates/portal/portal-deployment.yaml
@@ -80,7 +80,7 @@ spec:
         - name: {{ template "gravitee.portal.fullname" . }}
           image: "{{ .Values.portal.image.repository }}:{{ default .Chart.AppVersion .Values.portal.image.tag }}"
           imagePullPolicy: {{ .Values.portal.image.pullPolicy }}
-          securityContext: {{ toYaml ( .Values.portal.securityContext | default .Values.portal.deployment.securityContext ) | nindent 12 }}
+          securityContext: {{include "common.container.securitycontext" (dict "currentSecurityContext" .Values.portal.securityContext "defaultSecurityContext" .Values.portal.deployment.securityContext "openshift" .Values.openshift)| nindent 12}}
           env:
             - name: PORTAL_API_URL
               value: "https://{{index .Values.api.ingress.portal.hosts 0 }}{{ .Values.api.ingress.portal.path }}/"

--- a/apim/3.x/templates/portal/portal-ingress.yaml
+++ b/apim/3.x/templates/portal/portal-ingress.yaml
@@ -17,7 +17,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   annotations:
     {{- if .Values.portal.ingress.annotations }}
-    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.portal.ingress.annotations "ingressClassName" .Values.portal.ingress.ingressClassName "context" $) | nindent 4 }}
+    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.portal.ingress.annotations "ingressClassName" .Values.portal.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
     {{- end }}
 spec:
   {{- if and .Values.portal.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}

--- a/apim/3.x/templates/ui/ui-deployment.yaml
+++ b/apim/3.x/templates/ui/ui-deployment.yaml
@@ -83,7 +83,7 @@ spec:
         - name: {{ template "gravitee.ui.fullname" . }}
           image: "{{ .Values.ui.image.repository }}:{{ default .Chart.AppVersion .Values.ui.image.tag }}"
           imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
-          securityContext: {{ toYaml ( .Values.ui.securityContext | default .Values.ui.deployment.securityContext ) | nindent 12 }}
+          securityContext: {{include "common.container.securitycontext" (dict "currentSecurityContext" .Values.ui.securityContext "defaultSecurityContext" .Values.ui.deployment.securityContext "openshift" .Values.openshift)| nindent 12}}
           env:
             - name: MGMT_API_URL
               value: "https://{{index .Values.api.ingress.management.hosts 0 }}{{ .Values.api.ingress.management.path }}/"

--- a/apim/3.x/templates/ui/ui-ingress.yaml
+++ b/apim/3.x/templates/ui/ui-ingress.yaml
@@ -17,7 +17,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   annotations:
     {{- if .Values.ui.ingress.annotations }}
-    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.ui.ingress.annotations "ingressClassName" .Values.ui.ingress.ingressClassName "context" $) | nindent 4 }}
+    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.ui.ingress.annotations "ingressClassName" .Values.ui.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
     {{- end }}
 spec:
   {{- if and .Values.ui.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}

--- a/apim/3.x/tests/api/deployment_openshift_test.yaml
+++ b/apim/3.x/tests/api/deployment_openshift_test.yaml
@@ -1,0 +1,170 @@
+suite: Test Management API OpenShift deployment
+templates:
+  - "api/api-deployment.yaml"
+  - "api/api-configmap.yaml"  
+tests:
+  - it: Verify that the security context from OpenShift attribute is used
+    template: api/api-deployment.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    #values:
+    #  - ./values/staging.yaml
+    set:
+      management:
+        type: jdbc
+      jdbc:
+        driver: postgresql
+      openshift:
+        enabled: true
+        securityContext:
+          runAsUser: 9999
+          runAsGroup: 9998
+          runAsNonRoot: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: graviteeio/apim-management-api:1.0.0-app
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 9998
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 9999
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: false
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsGroup
+          value: 9998
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+          value: 9999
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: false
+  - it: Verify that the security context from the api attribute is used in case openshift is disabled
+    template: api/api-deployment.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    #values:
+    #  - ./values/staging.yaml
+    set:
+      management:
+        type: jdbc
+      jdbc:
+        driver: postgresql
+      openshift:
+        enabled: false
+        securityContext:
+          runAsUser: 9999
+          runAsGroup: 9998
+          runAsNonRoot: false
+      api:
+        securityContext:
+          runAsUser: 8888
+          runAsGroup: 8887
+          runAsNonRoot: true
+        deployment:
+          securityContext:
+            runAsUser: 7777
+            runAsGroup: 7776
+            runAsNonRoot: true
+      initContainers:
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 6666
+          runAsGroup: 6665
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: graviteeio/apim-management-api:1.0.0-app
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 8887
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 8888
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsGroup
+          value: 6665
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+          value: 6666
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: true
+  - it: Verify that the security context from the api deployment attribute is used in case openshift is disabled and the api security content is null
+    template: api/api-deployment.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    #values:
+    #  - ./values/staging.yaml
+    set:
+      management:
+        type: jdbc
+      jdbc:
+        driver: postgresql
+      openshift:
+        enabled: false
+        securityContext:
+          runAsUser: 9999
+          runAsGroup: 9998
+          runAsNonRoot: false
+      api:
+        securityContext: null
+        deployment:
+          securityContext:
+            runAsUser: 7777
+            runAsGroup: 7776
+            runAsNonRoot: true
+      initContainers:
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 6666
+          runAsGroup: 6665
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: graviteeio/apim-management-api:1.0.0-app
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 7776
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 7777
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsGroup
+          value: 6665
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+          value: 6666
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: true       

--- a/apim/3.x/tests/api/deployment_test.yaml
+++ b/apim/3.x/tests/api/deployment_test.yaml
@@ -1,4 +1,4 @@
-suite: Test Management API default deployment
+suite: Test Management API OpenShift deployment
 templates:
   - "api/api-deployment.yaml"
   - "api/api-configmap.yaml"

--- a/apim/3.x/tests/api/ingress_management_openshift_test.yaml
+++ b/apim/3.x/tests/api/ingress_management_openshift_test.yaml
@@ -1,0 +1,81 @@
+suite: Test Management API - Management Ingress for OpenShift
+templates:
+  - "api/api-ingress-management.yaml"
+tests:
+  - it: Check that the annotation kubernetes.io/ingress.class is removed if OpenShift is enabled
+    set:
+      openshift:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: edge
+  - it: Check that the annotation route.openshift.io/termination is using the value from openshift 
+    set:
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is enabled and generateRoute is set to false
+    set:
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: false
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is disabled and no annotations are added from openshift ingress attribute
+    set:
+      openshift:
+        enabled: false
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - isNull:
+          path: metadata.annotations.[route.openshift.io/termination]

--- a/apim/3.x/tests/api/ingress_portal_openshift_test.yaml
+++ b/apim/3.x/tests/api/ingress_portal_openshift_test.yaml
@@ -1,0 +1,81 @@
+suite: Test Management API - Portal Ingress for OpenShift
+templates:
+  - "api/api-ingress-portal.yaml"
+tests:
+  - it: Check that the annotation kubernetes.io/ingress.class is removed if OpenShift is enabled
+    set:
+      openshift:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: edge
+  - it: Check that the annotation route.openshift.io/termination is using the value from openshift 
+    set:
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is enabled and generateRoute is set to false
+    set:
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: false
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is disabled and no annotations are added from openshift ingress attribute
+    set:
+      openshift:
+        enabled: false
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - isNull:
+          path: metadata.annotations.[route.openshift.io/termination]

--- a/apim/3.x/tests/api/ingress_technical_openshift_test.yaml
+++ b/apim/3.x/tests/api/ingress_technical_openshift_test.yaml
@@ -1,0 +1,144 @@
+suite: Test Management API - Technical API Ingress for OpenShift
+templates:
+  - "api/api-technical-ingress.yaml"
+tests:
+  - it: Check that the annotation kubernetes.io/ingress.class is removed if OpenShift is enabled
+    set:
+    #.Values.api.http.services.core.ingress.annotations
+      api:
+        http:
+          services:
+            core:
+              ingress:
+                enabled: true
+                annotations:
+                  kubernetes.io/ingress.class: nginx
+                  nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: true        
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: edge
+  - it: Check that the annotation route.openshift.io/termination is using the value from openshift 
+    set:
+      api:
+        http:
+          services:
+            core:
+              ingress:
+                enabled: true
+                annotations:
+                  kubernetes.io/ingress.class: nginx
+                  nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is enabled and generateRoute is set to false
+    set:
+      api:
+        http:
+          services:
+            core:
+              ingress:
+                enabled: true
+                annotations:
+                  kubernetes.io/ingress.class: nginx
+                  nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: false
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is disabled and no annotations are added from openshift ingress attribute
+    set:
+      api:
+        http:
+          services:
+            core:
+              ingress:
+                enabled: true
+                annotations:
+                  kubernetes.io/ingress.class: nginx
+                  nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: false
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - isNull:
+          path: metadata.annotations.[route.openshift.io/termination]
+  - it: Check that the annotation kubernetes.io/ingress.class is removed if OpenShift is enabled, even if the value is not nginx
+    set:
+    #.Values.api.http.services.core.ingress.annotations
+      api:
+        http:
+          services:
+            core:
+              ingress:
+                enabled: true
+                annotations:
+                  kubernetes.io/ingress.class: traefik
+                  nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: true        
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: edge

--- a/apim/3.x/tests/gateway/deployment_openshift_test.yaml
+++ b/apim/3.x/tests/gateway/deployment_openshift_test.yaml
@@ -1,0 +1,170 @@
+suite: Test Management gateway OpenShift deployment
+templates:
+  - "gateway/gateway-deployment.yaml"
+  - "gateway/gateway-configmap.yaml"
+tests:
+  - it: Verify that the security context from OpenShift attribute is used
+    template: gateway/gateway-deployment.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    #values:
+    #  - ./values/staging.yaml
+    set:
+      management:
+        type: jdbc
+      jdbc:
+        driver: postgresql
+      openshift:
+        enabled: true
+        securityContext:
+          runAsUser: 9999
+          runAsGroup: 9998
+          runAsNonRoot: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: graviteeio/apim-gateway:1.0.0-app
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 9998
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 9999
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: false
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsGroup
+          value: 9998
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+          value: 9999
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: false
+  - it: Verify that the security context from the api attribute is used in case openshift is disabled
+    template: gateway/gateway-deployment.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    #values:
+    #  - ./values/staging.yaml
+    set:
+      management:
+        type: jdbc
+      jdbc:
+        driver: postgresql
+      openshift:
+        enabled: false
+        securityContext:
+          runAsUser: 9999
+          runAsGroup: 9998
+          runAsNonRoot: false
+      gateway:
+        securityContext:
+          runAsUser: 8888
+          runAsGroup: 8887
+          runAsNonRoot: true
+        deployment:
+          securityContext:
+            runAsUser: 7777
+            runAsGroup: 7776
+            runAsNonRoot: true
+      initContainers:
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 6666
+          runAsGroup: 6665
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: graviteeio/apim-gateway:1.0.0-app
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 8887
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 8888
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsGroup
+          value: 6665
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+          value: 6666
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: true
+  - it: Verify that the security context from the api deployment attribute is used in case openshift is disabled and the api security content is null
+    template: gateway/gateway-deployment.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    #values:
+    #  - ./values/staging.yaml
+    set:
+      management:
+        type: jdbc
+      jdbc:
+        driver: postgresql
+      openshift:
+        enabled: false
+        securityContext:
+          runAsUser: 9999
+          runAsGroup: 9998
+          runAsNonRoot: false
+      gateway:
+        securityContext: null
+        deployment:
+          securityContext:
+            runAsUser: 7777
+            runAsGroup: 7776
+            runAsNonRoot: true
+      initContainers:
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 6666
+          runAsGroup: 6665
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: graviteeio/apim-gateway:1.0.0-app
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 7776
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 7777
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsGroup
+          value: 6665
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+          value: 6666
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: true

--- a/apim/3.x/tests/gateway/ingress_bridge_openshift_test.yaml
+++ b/apim/3.x/tests/gateway/ingress_bridge_openshift_test.yaml
@@ -1,0 +1,172 @@
+suite: Test API Gateway Ingress with Hybrid Bridge enabled for OpenShift
+templates:
+  - "gateway/gateway-bridge-ingress.yaml"
+tests:
+  - it: Check that the annotation kubernetes.io/ingress.class is removed if OpenShift is enabled
+    set:
+      gateway:
+        services:
+          bridge:
+            enabled: true
+            service:
+              externalPort: 92
+              internalPort: 18092
+            ingress:
+              enabled: true
+              path: /gateway/_bridge
+              hosts:
+              - apim.example.com
+              annotations:
+                kubernetes.io/ingress.class: nginx
+                nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: edge
+  - it: Check that the annotation route.openshift.io/termination is using the value from openshift 
+    set:
+      gateway:
+        services:
+          bridge:
+            enabled: true
+            service:
+              externalPort: 92
+              internalPort: 18092
+            ingress:
+              enabled: true
+              path: /gateway/_bridge
+              hosts:
+              - apim.example.com
+              annotations:
+                kubernetes.io/ingress.class: nginx
+                nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is enabled and generateRoute is set to false
+    set:
+      gateway:
+        services:
+          bridge:
+            enabled: true
+            service:
+              externalPort: 92
+              internalPort: 18092
+            ingress:
+              enabled: true
+              path: /gateway/_bridge
+              hosts:
+              - apim.example.com
+              annotations:
+                kubernetes.io/ingress.class: nginx
+                nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: false
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is disabled and no annotations are added from openshift ingress attribute
+    set:
+      gateway:
+        services:
+          bridge:
+            enabled: true
+            service:
+              externalPort: 92
+              internalPort: 18092
+            ingress:
+              enabled: true
+              path: /gateway/_bridge
+              hosts:
+              - apim.example.com
+              annotations:
+                kubernetes.io/ingress.class: nginx
+                nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: false
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - isNull:
+          path: metadata.annotations.[route.openshift.io/termination]
+  - it: Check that the annotation kubernetes.io/ingress.class is removed if OpenShift is enabled, even if the value is not nginx
+    set:
+      gateway:
+        services:
+          bridge:
+            enabled: true
+            service:
+              externalPort: 92
+              internalPort: 18092
+            ingress:
+              enabled: true
+              path: /gateway/_bridge
+              hosts:
+              - apim.example.com
+              annotations:
+                kubernetes.io/ingress.class: traefik
+                nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: edge

--- a/apim/3.x/tests/gateway/ingress_openshift_test.yaml
+++ b/apim/3.x/tests/gateway/ingress_openshift_test.yaml
@@ -1,0 +1,81 @@
+suite: Test API Gateway Ingress for OpenShift
+templates:
+  - "gateway/gateway-ingress.yaml"
+tests:
+  - it: Check that the annotation kubernetes.io/ingress.class is removed if OpenShift is enabled
+    set:
+      openshift:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: edge
+  - it: Check that the annotation route.openshift.io/termination is using the value from openshift 
+    set:
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is enabled and generateRoute is set to false
+    set:
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: false
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is disabled and no annotations are added from openshift ingress attribute
+    set:
+      openshift:
+        enabled: false
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - isNull:
+          path: metadata.annotations.[route.openshift.io/termination]

--- a/apim/3.x/tests/gateway/ingress_technical_openshift_test.yaml
+++ b/apim/3.x/tests/gateway/ingress_technical_openshift_test.yaml
@@ -1,0 +1,137 @@
+suite: Test API Gateway - Technical API Ingress for OpenShift
+templates:
+  - "gateway/gateway-technical-ingress.yaml"
+tests:
+  - it: Check that the annotation kubernetes.io/ingress.class is removed if OpenShift is enabled
+    set:
+      gateway:
+        services:
+          core:
+            ingress:
+              enabled: true
+              annotations:
+                kubernetes.io/ingress.class: nginx
+                nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: edge
+  - it: Check that the annotation route.openshift.io/termination is using the value from openshift 
+    set:
+      gateway:
+        services:
+          core:
+            ingress:
+              enabled: true
+              annotations:
+                kubernetes.io/ingress.class: nginx
+                nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is enabled and generateRoute is set to false
+    set:
+      gateway:
+        services:
+          core:
+            ingress:
+              enabled: true
+              annotations:
+                kubernetes.io/ingress.class: nginx
+                nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: false
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is disabled and no annotations are added from openshift ingress attribute
+    set:
+      gateway:
+        services:
+          core:
+            ingress:
+              enabled: true
+              annotations:
+                kubernetes.io/ingress.class: nginx
+                nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: false
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - isNull:
+          path: metadata.annotations.[route.openshift.io/termination]
+  - it: Check that the annotation kubernetes.io/ingress.class is removed if OpenShift is enabled, even if the value is not nginx
+    set:
+      gateway:
+        services:
+          core:
+            ingress:
+              enabled: true
+              annotations:
+                kubernetes.io/ingress.class: traefik
+                nginx.ingress.kubernetes.io/rewrite-target: /_$1
+      openshift:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: edge

--- a/apim/3.x/tests/portal/deployment_openshift_test.yaml
+++ b/apim/3.x/tests/portal/deployment_openshift_test.yaml
@@ -1,0 +1,121 @@
+suite: Test Management Portal OpenShift deployment
+templates:
+  - "portal/portal-deployment.yaml"
+  - "portal/portal-configmap.yaml"
+tests:
+  - it: Verify that the security context from OpenShift attribute is used
+    template: portal/portal-deployment.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    #values:
+    #  - ./values/staging.yaml
+    set:
+      openshift:
+        enabled: true
+        securityContext:
+          runAsUser: 9999
+          runAsGroup: 9998
+          runAsNonRoot: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: graviteeio/apim-portal-ui:1.0.0-app
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 9998
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 9999
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: false
+  - it: Verify that the security context from the api attribute is used in case openshift is disabled
+    template: portal/portal-deployment.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    #values:
+    #  - ./values/staging.yaml
+    set:
+      openshift:
+        enabled: false
+        securityContext:
+          runAsUser: 9999
+          runAsGroup: 9998
+          runAsNonRoot: false
+      portal:
+        securityContext:
+          runAsUser: 8888
+          runAsGroup: 8887
+          runAsNonRoot: true
+        deployment:
+          securityContext:
+            runAsUser: 7777
+            runAsGroup: 7776
+            runAsNonRoot: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: graviteeio/apim-portal-ui:1.0.0-app
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 8887
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 8888
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+  - it: Verify that the security context from the api deployment attribute is used in case openshift is disabled and the api security content is null
+    template: portal/portal-deployment.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    #values:
+    #  - ./values/staging.yaml
+    set:
+      openshift:
+        enabled: false
+        securityContext:
+          runAsUser: 9999
+          runAsGroup: 9998
+          runAsNonRoot: false
+      portal:
+        securityContext: null
+        deployment:
+          securityContext:
+            runAsUser: 7777
+            runAsGroup: 7776
+            runAsNonRoot: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: graviteeio/apim-portal-ui:1.0.0-app
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 7776
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 7777
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true

--- a/apim/3.x/tests/portal/ingress_openshift_test.yaml
+++ b/apim/3.x/tests/portal/ingress_openshift_test.yaml
@@ -1,0 +1,81 @@
+suite: Test Portal Ingress for OpenShift
+templates:
+  - "portal/portal-ingress.yaml"
+tests:
+  - it: Check that the annotation kubernetes.io/ingress.class is removed if OpenShift is enabled
+    set:
+      openshift:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: edge
+  - it: Check that the annotation route.openshift.io/termination is using the value from openshift 
+    set:
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is enabled and generateRoute is set to false
+    set:
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: false
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is disabled and no annotations are added from openshift ingress attribute
+    set:
+      openshift:
+        enabled: false
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - isNull:
+          path: metadata.annotations.[route.openshift.io/termination]

--- a/apim/3.x/tests/ui/deployment_openshift_test.yaml
+++ b/apim/3.x/tests/ui/deployment_openshift_test.yaml
@@ -1,0 +1,121 @@
+suite: Test Management UI OpenShift deployment
+templates:
+  - "ui/ui-deployment.yaml"
+  - "ui/ui-configmap.yaml"
+tests:
+  - it: Verify that the security context from OpenShift attribute is used
+    template: ui/ui-deployment.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    #values:
+    #  - ./values/staging.yaml
+    set:
+      openshift:
+        enabled: true
+        securityContext:
+          runAsUser: 9999
+          runAsGroup: 9998
+          runAsNonRoot: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: graviteeio/apim-management-ui:1.0.0-app
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 9998
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 9999
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: false
+  - it: Verify that the security context from the api attribute is used in case openshift is disabled
+    template: ui/ui-deployment.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    #values:
+    #  - ./values/staging.yaml
+    set:
+      openshift:
+        enabled: false
+        securityContext:
+          runAsUser: 9999
+          runAsGroup: 9998
+          runAsNonRoot: false
+      ui:
+        securityContext:
+          runAsUser: 8888
+          runAsGroup: 8887
+          runAsNonRoot: true
+        deployment:
+          securityContext:
+            runAsUser: 7777
+            runAsGroup: 7776
+            runAsNonRoot: true          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: graviteeio/apim-management-ui:1.0.0-app
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 8887
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 8888
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+  - it: Verify that the security context from the api deployment attribute is used in case openshift is disabled and the api security content is null
+    template: ui/ui-deployment.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    #values:
+    #  - ./values/staging.yaml
+    set:
+      openshift:
+        enabled: false
+        securityContext:
+          runAsUser: 9999
+          runAsGroup: 9998
+          runAsNonRoot: false
+      ui:
+        securityContext: null
+        deployment:
+          securityContext:
+            runAsUser: 7777
+            runAsGroup: 7776
+            runAsNonRoot: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: graviteeio/apim-management-ui:1.0.0-app
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 7776
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 7777
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true          

--- a/apim/3.x/tests/ui/ingress_openshift_test.yaml
+++ b/apim/3.x/tests/ui/ingress_openshift_test.yaml
@@ -1,0 +1,81 @@
+suite: Test Console Ingress for OpenShift
+templates:
+  - "ui/ui-ingress.yaml"
+tests:
+  - it: Check that the annotation kubernetes.io/ingress.class is removed if OpenShift is enabled
+    set:
+      openshift:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: edge
+  - it: Check that the annotation route.openshift.io/termination is using the value from openshift 
+    set:
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - isNull:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is enabled and generateRoute is set to false
+    set:
+      openshift:
+        enabled: true
+        ingress:
+          generateRoute: false
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - equal:
+          path: metadata.annotations.[route.openshift.io/termination]
+          value: reencrypt
+  - it: Check that the annotation kubernetes.io/ingress.class is not removed if OpenShift is disabled and no annotations are added from openshift ingress attribute
+    set:
+      openshift:
+        enabled: false
+        ingress:
+          generateRoute: true
+          annotations:
+            route.openshift.io/termination: "reencrypt"          
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations.[kubernetes.io/ingress.class]
+          value: nginx
+      - isNull:
+          path: metadata.annotations.[route.openshift.io/termination]

--- a/apim/3.x/values.yaml
+++ b/apim/3.x/values.yaml
@@ -408,7 +408,7 @@ api:
     # - configMapRef:
     #     name: config-secret
     securityContext:
-      runAsUser: 1001
+      runAsUser: 1003
       runAsNonRoot: true
     strategy:
       type: RollingUpdate
@@ -1271,3 +1271,15 @@ initContainers:
     runAsUser: 1001
     runAsNonRoot: true
   env: []
+
+openshift:
+  enabled: false
+  securityContext:
+    runAsUser: null
+    runAsGroup: null
+    runAsNonRoot: true
+  ingress:
+    generateRoute: true
+    annotations:
+      route.openshift.io/termination: "edge"
+


### PR DESCRIPTION
…e rollout of gravitee in an OpenShift cluster

**Issue**

No issue

**Description**

During the deployment of Gravitee on OpenShift for IGS, we encountered two major problems:
1. OpenShift requires to start the pods with a "unique" user id, for this we needed to explicit overwrite the securityContext attribute for each deployment in the customes yaml file for APIM, AM and AE.
2. The ingress traffic in OpenShift is based on routes that are usually created from Ingress resources. This is not working at the moment because Ingress resource define a nginx ingress class that doesn't exist on most of the OpenShift cluster (most customer use the default ingress)

With this pull request I address these problems. Could you please verify if the changes are okay, then I'm going to modify the AM and AE as well.
