### PR TITLE
fix(cockpit): use ISO8601 timezone in json logging

### DIFF
--- a/cockpit/CHANGELOG.md
+++ b/cockpit/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to [Gravitee.io Cockpit](https://github.com/gravitee-io/helm-charts/tree/master/cockpit) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 1.6.22
+
+- [X] Use ISO 8601 datetime for cockpit json logging
+
 ### 1.6.21
 
 - [X] Fix json logging to log one message per line

--- a/cockpit/Chart.yaml
+++ b/cockpit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: cockpit
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 1.6.21
+version: 1.6.22
 appVersion: 3.16.0
 description: Official Gravitee.io Helm chart for Cockpit
 home: https://gravitee.io
@@ -21,4 +21,4 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/cockpit?modal=changelog
   artifacthub.io/changes: |
-    - Fix json logging to log one message per line
+    - Use ISO 8601 datetime for cockpit json logging

--- a/cockpit/templates/api/api-configmap.yaml
+++ b/cockpit/templates/api/api-configmap.yaml
@@ -278,7 +278,7 @@ data:
                             class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
                     </jsonFormatter>
                     <appendLineSeparator>true</appendLineSeparator>
-                    <timestampFormat>yyyy-MM-dd' 'HH:mm:ss.SSS</timestampFormat>
+                    <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSXX</timestampFormat>
                 </layout>
               </encoder>
               {{- else }}

--- a/cockpit/tests/api/api-configmap_logback_yaml_test.yaml
+++ b/cockpit/tests/api/api-configmap_logback_yaml_test.yaml
@@ -95,7 +95,7 @@ tests:
                                     class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
                             </jsonFormatter>
                             <appendLineSeparator>true</appendLineSeparator>
-                            <timestampFormat>yyyy-MM-dd' 'HH:mm:ss.SSS</timestampFormat>
+                            <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSXX</timestampFormat>
                         </layout>
                       </encoder>
                     </appender>


### PR DESCRIPTION

**Description**

Use ISO 8601 timezone representation in json logging to fix filebeat parsing problems ([stackoverflow thread](https://stackoverflow.com/questions/57920043/failing-to-parse-date-in-logstash-with-format-strict-date-optional-timeepoch))
