### PR TITLE
fix: error port name too long

### DIFF
--- a/apim/3.x/templates/api/api-deployment.yaml
+++ b/apim/3.x/templates/api/api-deployment.yaml
@@ -110,11 +110,11 @@ spec:
             - name: {{ .Values.api.service.internalPortName }}
               containerPort: {{ .Values.api.service.internalPort }}
             {{- if .Values.api.http.services.core.http.enabled }}
-            - name: {{- printf "%s-%s" .Values.api.name "techapi" | trunc 15 }}
+            - name: {{ printf "%s-%s" (.Values.api.name | trunc 8 | trimSuffix "-") "techapi" }}
               containerPort: {{ .Values.api.http.services.core.http.port | default "18083" }}
             {{- end }}
             {{- if .Values.api.services.bridge.enabled }}
-            - name: {{- printf "%s-%s" .Values.api.name "bridge" | trunc 15 }}
+            - name: {{ printf "%s-%s" (.Values.api.name | trunc 8 | trimSuffix "-") "bridge" }}
               containerPort: {{ .Values.api.services.bridge.service.internalPort }}
             {{- end }}
           env:

--- a/apim/3.x/templates/api/api-deployment.yaml
+++ b/apim/3.x/templates/api/api-deployment.yaml
@@ -110,11 +110,11 @@ spec:
             - name: {{ .Values.api.service.internalPortName }}
               containerPort: {{ .Values.api.service.internalPort }}
             {{- if .Values.api.http.services.core.http.enabled }}
-            - name: {{ .Values.api.name }}-techapi
+            - name: {{- printf "%s-%s" .Values.api.name "techapi" | trunc 15 }}
               containerPort: {{ .Values.api.http.services.core.http.port | default "18083" }}
             {{- end }}
             {{- if .Values.api.services.bridge.enabled }}
-            - name: {{ .Values.api.name }}-bridge
+            - name: {{- printf "%s-%s" .Values.api.name "bridge" | trunc 15 }}
               containerPort: {{ .Values.api.services.bridge.service.internalPort }}
             {{- end }}
           env:

--- a/apim/3.x/templates/gateway/gateway-deployment.yaml
+++ b/apim/3.x/templates/gateway/gateway-deployment.yaml
@@ -128,11 +128,11 @@ spec:
             - name: {{ .Values.gateway.service.internalPortName }}
               containerPort: {{ .Values.gateway.service.internalPort }}
             {{- if .Values.gateway.services.bridge.enabled }}
-            - name: {{- printf "%s-%s" .Values.gateway.name "bridge" | trunc 15 }}
+            - name: {{ printf "%s-%s" (.Values.gateway.name | trunc 8 | trimSuffix "-") "bridge" }}
               containerPort: {{ .Values.gateway.services.bridge.service.internalPort }}
             {{- end }}
             {{- if and .Values.gateway.services.core.http.enabled (or .Values.gateway.services.kubeController.enabled .Values.gateway.readinessProbe.apiSync) }}
-            - name: {{- printf "%s-%s" .Values.gateway.name "techapi" | trunc 15 }}
+            - name: {{ printf "%s-%s" (.Values.gateway.name | trunc 8 | trimSuffix "-") "techapi" }}
               containerPort: {{ .Values.gateway.services.core.http.port | default "18082" }}
             {{- end }}
           env:

--- a/apim/3.x/templates/gateway/gateway-deployment.yaml
+++ b/apim/3.x/templates/gateway/gateway-deployment.yaml
@@ -128,11 +128,11 @@ spec:
             - name: {{ .Values.gateway.service.internalPortName }}
               containerPort: {{ .Values.gateway.service.internalPort }}
             {{- if .Values.gateway.services.bridge.enabled }}
-            - name: {{ .Values.gateway.name }}-bridge
+            - name: {{- printf "%s-%s" .Values.gateway.name "bridge" | trunc 15 }}
               containerPort: {{ .Values.gateway.services.bridge.service.internalPort }}
             {{- end }}
             {{- if and .Values.gateway.services.core.http.enabled (or .Values.gateway.services.kubeController.enabled .Values.gateway.readinessProbe.apiSync) }}
-            - name: {{ .Values.gateway.name }}-techapi
+            - name: {{- printf "%s-%s" .Values.gateway.name "techapi" | trunc 15 }}
               containerPort: {{ .Values.gateway.services.core.http.port | default "18082" }}
             {{- end }}
           env:


### PR DESCRIPTION
**Issue**

[#8345](https://github.com/gravitee-io/issues/issues/8345)

**Description**

Following the following error during a test deployment.  
helm-controller reconciliation failed: Helm upgrade failed: failed to create resource: Deployment.apps "abc-d-01--abcd-efg" is invalid: spec.template.spec.containers[0].ports[1].name: Invalid value: "abcd-efg-techapi": must be no more than 15 characters  
To solve it, I just truncate port name for bridge and technical port on api and gateway deployment templates.

**Additional context**

We are trying to deploy 2 control plane on the same cluster and must rename the release, deployments and pods.
