### PR TITLE
fix(apim): use ISO8601 timezone in json logging

### DIFF
--- a/apim/3.x/CHANGELOG.md
+++ b/apim/3.x/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 3.1.52
+
+- [X] Use ISO 8601 datetime for apim json logging
+
 ### 3.1.51
 
 - [X] Add JSON logging support

--- a/apim/3.x/Chart.yaml
+++ b/apim/3.x/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: apim3
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 3.1.51
+version: 3.1.52
 appVersion: 3.15.10
 description: Official Gravitee.io Helm chart for API Management 3.x
 home: https://gravitee.io
@@ -20,5 +20,4 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/apim3?modal=changelog
   artifacthub.io/changes: |
-    - Add JSON logging support
-    - Accept some special characters in Management URL of API configmap. 
+    - Use ISO 8601 datetime for apim json logging 

--- a/apim/3.x/templates/api/api-configmap.yaml
+++ b/apim/3.x/templates/api/api-configmap.yaml
@@ -501,7 +501,7 @@ data:
                               class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
                       </jsonFormatter>
                       <appendLineSeparator>true</appendLineSeparator>
-                      <timestampFormat>yyyy-MM-dd' 'HH:mm:ss.SSS</timestampFormat>
+                      <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSXX</timestampFormat>
                   </layout>
               </encoder>
               {{- else }}

--- a/apim/3.x/templates/gateway/gateway-configmap.yaml
+++ b/apim/3.x/templates/gateway/gateway-configmap.yaml
@@ -414,7 +414,7 @@ data:
                             class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
                     </jsonFormatter>
                     <appendLineSeparator>true</appendLineSeparator>
-                    <timestampFormat>yyyy-MM-dd' 'HH:mm:ss.SSS</timestampFormat>
+                    <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSXX</timestampFormat>
                 </layout>
             </encoder>
             {{- else }}

--- a/apim/3.x/tests/api/configmap_logback_yaml_test.yaml
+++ b/apim/3.x/tests/api/configmap_logback_yaml_test.yaml
@@ -107,7 +107,7 @@ tests:
                                       class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
                               </jsonFormatter>
                               <appendLineSeparator>true</appendLineSeparator>
-                              <timestampFormat>yyyy-MM-dd' 'HH:mm:ss.SSS</timestampFormat>
+                              <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSXX</timestampFormat>
                           </layout>
                       </encoder>
                   </appender>

--- a/apim/3.x/tests/gateway/configmap_logback_yaml_test.yaml
+++ b/apim/3.x/tests/gateway/configmap_logback_yaml_test.yaml
@@ -124,7 +124,7 @@ tests:
                                     class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
                             </jsonFormatter>
                             <appendLineSeparator>true</appendLineSeparator>
-                            <timestampFormat>yyyy-MM-dd' 'HH:mm:ss.SSS</timestampFormat>
+                            <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSXX</timestampFormat>
                         </layout>
                     </encoder>
                 </appender>


### PR DESCRIPTION
**Description**

Use ISO 8601 timezone representation in json logging to fix filebeat parsing problems

see https://stackoverflow.com/questions/57920043/failing-to-parse-date-in-logstash-with-format-strict-date-optional-timeepoch
see https://github.com/gravitee-io/helm-charts/pull/290
