### PR TITLE
Add a startup probe on m-api

### DIFF
--- a/apim/3.x/CHANGELOG.md
+++ b/apim/3.x/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 3.1.54
+
+- [X] Add a startup probe on the Management API
+
 ### 3.1.53
 
 - [X] Remove alias for mongodb chart dependency
-- 
+
 ### 3.1.52
 
 - [X] Use ISO 8601 datetime for apim json logging

--- a/apim/3.x/Chart.yaml
+++ b/apim/3.x/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: apim3
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 3.1.53
+version: 3.1.54
 appVersion: 3.15.10
 description: Official Gravitee.io Helm chart for API Management 3.x
 home: https://gravitee.io
@@ -20,4 +20,4 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/apim3?modal=changelog
   artifacthub.io/changes: |
-    - Remove alias for mongodb chart dependency
+    - Add a startup probe on the Management API

--- a/apim/3.x/tests/api/deployment_livenessProbe_test.yaml
+++ b/apim/3.x/tests/api/deployment_livenessProbe_test.yaml
@@ -1,0 +1,35 @@
+suite: Test Management API deployment with livenessProbe
+templates:
+  - "api/api-deployment.yaml"
+  - "api/api-configmap.yaml"
+tests:
+  - it: Check default livenessProbe with Kubernetes >= 1.18-0
+    template: api/api-deployment.yaml
+    capabilities:
+      KubeVersion: "1.18-0"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.tcpSocket.port
+          value: http
+  - it: Check custom livenessProbe
+    template: api/api-deployment.yaml
+    set:
+      api:
+        livenessProbe:
+          httpGet:
+            path: /_node/sync
+            port: 18083
+            scheme: HTTPS
+            httpHeaders:
+                - name: Authorization
+                  value: my_password
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /_node/sync
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 18083
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.scheme
+          value: HTTPS

--- a/apim/3.x/tests/api/deployment_readinessProbe_test.yaml
+++ b/apim/3.x/tests/api/deployment_readinessProbe_test.yaml
@@ -1,0 +1,35 @@
+suite: Test Management API deployment with readinessProbe
+templates:
+  - "api/api-deployment.yaml"
+  - "api/api-configmap.yaml"
+tests:
+  - it: Check default readinessProbe with Kubernetes >= 1.18-0
+    template: api/api-deployment.yaml
+    capabilities:
+      KubeVersion: "1.18-0"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
+          value: http
+  - it: Check custom readinessProbe
+    template: api/api-deployment.yaml
+    set:
+      api:
+        readinessProbe:
+          httpGet:
+            path: /_node/sync
+            port: 18083
+            scheme: HTTPS
+            httpHeaders:
+                - name: Authorization
+                  value: my_password
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /_node/sync
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 18083
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+          value: HTTPS

--- a/apim/3.x/tests/api/deployment_startupProbe_test.yaml
+++ b/apim/3.x/tests/api/deployment_startupProbe_test.yaml
@@ -1,0 +1,13 @@
+suite: Test Management API deployment with startupProbe
+templates:
+  - "api/api-deployment.yaml"
+  - "api/api-configmap.yaml"
+tests:
+  - it: Check default startupProbe with Kubernetes >= 1.18-0
+    template: api/api-deployment.yaml
+    capabilities:
+      KubeVersion: "1.18-0"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.tcpSocket.port
+          value: http

--- a/apim/3.x/values.yaml
+++ b/apim/3.x/values.yaml
@@ -431,6 +431,12 @@ api:
     periodSeconds: 30
     failureThreshold: 3
 
+  startupProbe:
+    tcpSocket:
+      port: http
+    failureThreshold: 30
+    periodSeconds: 10
+  
   pdb:
     enabled: false
     minAvailable: ""


### PR DESCRIPTION
**Description**

Depending on the time to execute java upgraders during a version upgrade, we encountered issues when k8s restarted the pod even if the upgrade was not finished.
The "workaround" is to add a startup probe to accept a long initial startup.