### PR TITLE
fix(apim): remove alias for mongodb chart dependency

### DIFF
--- a/apim/3.x/CHANGELOG.md
+++ b/apim/3.x/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 3.1.53
+
+- [X] Remove alias for mongodb chart dependency
+- 
 ### 3.1.52
 
 - [X] Use ISO 8601 datetime for apim json logging

--- a/apim/3.x/Chart.yaml
+++ b/apim/3.x/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: apim3
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 3.1.52
+version: 3.1.53
 appVersion: 3.15.10
 description: Official Gravitee.io Helm chart for API Management 3.x
 home: https://gravitee.io
@@ -20,4 +20,4 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/apim3?modal=changelog
   artifacthub.io/changes: |
-    - Use ISO 8601 datetime for apim json logging 
+    - Remove alias for mongodb chart dependency

--- a/apim/3.x/requirements.lock
+++ b/apim/3.x/requirements.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 17.9.29
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
-  version: 12.1.19
-digest: sha256:e360df73138e263eea9c4b2c9a3498b2fe254a933e952a2406063e14427138ca
-generated: "2022-06-10T09:28:28.993630817+01:00"
+  version: 12.1.31
+digest: sha256:cadd30897050977ffba932ebcdd0150be42d281f76f79fabef165979ddf0e783
+generated: "2022-08-25T09:31:12.780412+02:00"

--- a/apim/3.x/requirements.yaml
+++ b/apim/3.x/requirements.yaml
@@ -4,7 +4,6 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: elasticsearch.enabled
   - name: mongodb
-    alias: mongodb-replicaset
     version: ^12.1.7
     repository: https://charts.bitnami.com/bitnami
-    condition: mongodb-replicaset.enabled
+    condition: mongodb.enabled

--- a/apim/3.x/values.yaml
+++ b/apim/3.x/values.yaml
@@ -225,7 +225,7 @@ redis:
   download: true
 #  repositoryVersion: 3.3.0
 
-mongodb-replicaset:
+mongodb:
   enabled: false
   architecture: replicaset
   fullnameOverride: "graviteeio-apim-mongodb-replicaset"


### PR DESCRIPTION
**Description**

It seems that using an alias breaks the condition when we depend on multiple APIM chart.

For example, if we deploy an umbrella chart like:

```
apiVersion: v2
name: jgo
description: an environment
type: application
version: 1.0.0
appVersion: "1.0.0"

dependencies:
  - name: apim3
    version: 3.1.52
    repository: https://helm.gravitee.io
    alias: apim
  - name: apim3
    version: 3.1.52
    repository: https://helm.gravitee.io
    alias: apim-dev
```

It will create the following:
- Source: jgo/charts/apim-dev/charts/mongodb/templates/serviceaccount.yaml
- Source: jgo/charts/apim-dev/charts/mongodb/templates/secrets.yaml
- Source: jgo/charts/apim-dev/charts/mongodb/templates/common-scripts-cm.yaml
- Source: jgo/charts/apim-dev/charts/mongodb/templates/standalone/pvc.yaml
- Source: jgo/charts/apim-dev/charts/mongodb/templates/standalone/svc.yaml
- Source: jgo/charts/apim-dev/charts/mongodb/templates/standalone/dep-sts.yaml



**Additional context**
https://graviteeio.slack.com/archives/C02C0KPS8LB/p1661409816769749

