### PR TITLE
fix(apim): error port name too long

### DIFF
--- a/ae/CHANGELOG.md
+++ b/ae/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to [Gravitee.io Alert Engine](https://github.com/gravitee-io/helm-charts/tree/master/ae) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 1.1.39
+
+- [X] Trunc port name with k8s limit (63)
+
 ### 1.1.38
 
 - [X] Fix security context implementation

--- a/ae/Chart.yaml
+++ b/ae/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: ae
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 1.1.38
+version: 1.1.39
 appVersion: 1.6.4
 description: Official Gravitee.io Helm chart for Alert Engine
 home: https://gravitee.io

--- a/ae/templates/engine-deployment.yaml
+++ b/ae/templates/engine-deployment.yaml
@@ -103,7 +103,7 @@ spec:
             - name: {{ .Values.engine.service.internalPortName }}
               containerPort: {{ .Values.engine.service.internalPort }}
             {{- if .Values.engine.services.core.http.enabled }}
-            - name: {{ .Values.engine.name }}-techapi
+            - name: {{ printf "%s-%s" (.Values.engine.name | trunc 7 | trimSuffix "-") "techapi" }}
               containerPort: {{ .Values.engine.services.core.http.port | default "18072" }}
             {{- end }}
           env:

--- a/ae/templates/engine-service.yaml
+++ b/ae/templates/engine-service.yaml
@@ -31,9 +31,9 @@ spec:
       {{ end }}
       {{ end }}
       {{- end }}
-      name: {{ .Values.engine.name }}
+      name: {{ .Values.engine.name | trunc 63 | trimSuffix "-" }}
     - port: 5701
-      name: {{ .Values.engine.name }}-hz
+      name: {{ printf "%s-%s" (.Values.engine.name | trunc 60 | trimSuffix "-") "hz" }}
       protocol: TCP
       {{- if (include "common.service.supportsAppProtocol" .) }}
       {{ if .Values.engine.service.appProtocol }}
@@ -57,7 +57,7 @@ spec:
       appProtocol: http
       {{ end }}
       {{- end }}
-      name: {{ .Values.engine.name }}-techapi
+      name: {{ printf "%s-%s" (.Values.engine.name | trunc 55 | trimSuffix "-") "techapi" }}
     {{- end }}
   selector:
     app.kubernetes.io/name: {{ template "gravitee.name" . }}

--- a/am/CHANGELOG.md
+++ b/am/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 This file documents all notable changes to [Gravitee.io Access Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/am/) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+### 1.0.47
+
+- [X] Trunc port name with k8s limit (63)
 
 ### 1.0.46
 

--- a/am/Chart.yaml
+++ b/am/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: am
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 1.0.46
+version: 1.0.47
 appVersion: 3.15.9
 description: Official Gravitee.io Helm chart for Access Management
 home: https://gravitee.io

--- a/am/templates/api/api-service.yaml
+++ b/am/templates/api/api-service.yaml
@@ -31,7 +31,7 @@ spec:
       {{ end }}
       {{ end }}
       {{- end }}
-      name: {{ .Values.api.name }}
+      name: {{ .Values.api.name | trunc 63 | trimSuffix "-" }}
     {{- if .Values.api.http.services.core.service.enabled }}
     - port: {{ .Values.api.http.services.core.service.externalPort }}
       targetPort: {{ .Values.api.http.services.core.http.port }}
@@ -43,7 +43,7 @@ spec:
       appProtocol: http
       {{ end }}
       {{- end }}
-      name: {{ .Values.api.name }}-technical
+      name: {{ printf "%s-%s" (.Values.api.name | trunc 53 | trimSuffix "-") "technical" }}
     {{- end }}
   selector:
     app.kubernetes.io/name: {{ template "gravitee.name" . }}

--- a/am/templates/gateway/gateway-service.yaml
+++ b/am/templates/gateway/gateway-service.yaml
@@ -31,7 +31,7 @@ spec:
       {{ end }}
       {{ end }}
       {{- end }}
-      name: {{ .Values.gateway.name }}
+      name: {{ .Values.gateway.name | trunc 63 | trimSuffix "-" }}
     {{- if .Values.gateway.services.core.service.enabled }}
     - port: {{ .Values.gateway.services.core.service.externalPort }}
       targetPort: {{ .Values.gateway.services.core.http.port }}
@@ -43,7 +43,7 @@ spec:
       appProtocol: http
       {{ end }}
       {{- end }}
-      name: {{ .Values.gateway.name }}-technical
+      name: {{ printf "%s-%s" (.Values.gateway.name | trunc 53 | trimSuffix "-") "technical" }}
     {{- end }}
   selector:
     app.kubernetes.io/name: {{ template "gravitee.name" . }}

--- a/am/templates/ui/ui-service.yaml
+++ b/am/templates/ui/ui-service.yaml
@@ -27,7 +27,7 @@ spec:
       appProtocol: http
       {{ end }}
       {{- end }}
-      name: {{ .Values.ui.name }}
+      name: {{ .Values.ui.name | trunc 63 | trimSuffix "-" }}
   selector:
     app.kubernetes.io/name: {{ template "gravitee.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/am/tests/api/service_test.yaml
+++ b/am/tests/api/service_test.yaml
@@ -48,3 +48,34 @@ tests:
             protocol: TCP
             name: management-api
             appProtocol: http-test
+
+
+  - it: Deploy with long api name
+    template: api/api-service.yaml
+    set:
+      api:
+        name: "I-am-a-very-long-name-Neque-porro-quisquam-est-qui-dolorem-ipsum-quia-dolor-sit"
+        http:
+          services:
+            core:
+              service:
+                enabled: true
+                externalPort: 4242
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.ports
+          value: 
+            - appProtocol: http
+              name: I-am-a-very-long-name-Neque-porro-quisquam-est-qui-dolorem-ipsu
+              port: 83
+              protocol: TCP
+              targetPort: 8093
+            - appProtocol: http
+              name: I-am-a-very-long-name-Neque-porro-quisquam-est-qui-do-technical
+              port: 4242
+              protocol: TCP
+              targetPort: 18093

--- a/am/tests/gateway/service_test.yaml
+++ b/am/tests/gateway/service_test.yaml
@@ -48,3 +48,32 @@ tests:
             protocol: TCP
             name: gateway
             appProtocol: http-test
+
+  - it: Deploy with long api name
+    template: gateway/gateway-service.yaml
+    set:
+      gateway:
+        name: "I-am-a-very-long-name-Neque-porro-quisquam-est-qui-dolorem-ipsum-quia-dolor-sit"
+        services:
+          core:
+            service:
+              enabled: true
+              externalPort: 4242
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.ports
+          value: 
+            - appProtocol: http
+              name: I-am-a-very-long-name-Neque-porro-quisquam-est-qui-dolorem-ipsu
+              port: 82
+              protocol: TCP
+              targetPort: 8092
+            - appProtocol: http
+              name: I-am-a-very-long-name-Neque-porro-quisquam-est-qui-do-technical
+              port: 4242
+              protocol: TCP
+              targetPort: 18092

--- a/am/tests/ui/service_test.yaml
+++ b/am/tests/ui/service_test.yaml
@@ -48,3 +48,22 @@ tests:
             protocol: TCP
             name: management-ui
             appProtocol: http-test
+
+  - it: Deploy with long api name
+    template: ui/ui-service.yaml
+    set:
+      ui:
+        name: "I-am-a-very-long-name-Neque-porro-quisquam-est-qui-dolorem-ipsum-quia-dolor-sit"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.ports
+          value: 
+          - appProtocol: http
+            name: I-am-a-very-long-name-Neque-porro-quisquam-est-qui-dolorem-ipsu
+            port: 8002
+            protocol: TCP
+            targetPort: 8080

--- a/apim/3.x/CHANGELOG.md
+++ b/apim/3.x/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 3.1.55
+
+- [X] Trunc port name with k8s limit (15 for deployment and 63 for service)
+
 ### 3.1.54
 
 - [X] Add a startup probe on the Management API

--- a/apim/3.x/Chart.yaml
+++ b/apim/3.x/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: apim3
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 3.1.54
+version: 3.1.55
 appVersion: 3.15.10
 description: Official Gravitee.io Helm chart for API Management 3.x
 home: https://gravitee.io

--- a/apim/3.x/templates/api/api-deployment.yaml
+++ b/apim/3.x/templates/api/api-deployment.yaml
@@ -110,11 +110,11 @@ spec:
             - name: {{ .Values.api.service.internalPortName }}
               containerPort: {{ .Values.api.service.internalPort }}
             {{- if .Values.api.http.services.core.http.enabled }}
-            - name: {{ .Values.api.name }}-techapi
+            - name: {{ printf "%s-%s" (.Values.api.name | trunc 7 | trimSuffix "-") "techapi" }}
               containerPort: {{ .Values.api.http.services.core.http.port | default "18083" }}
             {{- end }}
             {{- if .Values.api.services.bridge.enabled }}
-            - name: {{ .Values.api.name }}-bridge
+            - name: {{ printf "%s-%s" (.Values.api.name | trunc 8 | trimSuffix "-") "bridge" }}
               containerPort: {{ .Values.api.services.bridge.service.internalPort }}
             {{- end }}
           env:

--- a/apim/3.x/templates/api/api-service.yaml
+++ b/apim/3.x/templates/api/api-service.yaml
@@ -31,7 +31,7 @@ spec:
       {{ end }}
       {{ end }}
       {{- end }}
-      name: {{ .Values.api.name }}
+      name: {{ .Values.api.name | trunc 63 | trimSuffix "-" }}
     {{- if .Values.api.http.services.core.service.enabled }}
     - port: {{ .Values.api.http.services.core.service.externalPort }}
       targetPort: {{ .Values.api.http.services.core.http.port }}
@@ -43,7 +43,7 @@ spec:
       appProtocol: http
       {{ end }}
       {{- end }}
-      name: {{ .Values.api.name }}-technical
+      name: {{ printf "%s-%s" (.Values.api.name | trunc 53 | trimSuffix "-") "technical" }}
     {{- end }}
     {{- if .Values.api.services.bridge.enabled }}
     - port: {{ .Values.api.services.bridge.service.externalPort }}
@@ -60,7 +60,7 @@ spec:
       {{ end }}
       {{ end }}
       {{- end }}
-      name: {{ .Values.api.name }}-bridge
+      name: {{ printf "%s-%s" (.Values.api.name | trunc 56 | trimSuffix "-") "bridge" }}
     {{- end }}
   selector:
     app.kubernetes.io/name: {{ template "gravitee.name" . }}

--- a/apim/3.x/templates/gateway/gateway-deployment.yaml
+++ b/apim/3.x/templates/gateway/gateway-deployment.yaml
@@ -128,11 +128,11 @@ spec:
             - name: {{ .Values.gateway.service.internalPortName }}
               containerPort: {{ .Values.gateway.service.internalPort }}
             {{- if .Values.gateway.services.bridge.enabled }}
-            - name: {{ .Values.gateway.name }}-bridge
+            - name: {{ printf "%s-%s" (.Values.gateway.name | trunc 8 | trimSuffix "-") "bridge" }}
               containerPort: {{ .Values.gateway.services.bridge.service.internalPort }}
             {{- end }}
             {{- if and .Values.gateway.services.core.http.enabled (or .Values.gateway.services.kubeController.enabled .Values.gateway.readinessProbe.apiSync) }}
-            - name: {{ .Values.gateway.name }}-techapi
+            - name: {{ printf "%s-%s" (.Values.gateway.name | trunc 7 | trimSuffix "-") "techapi" }}
               containerPort: {{ .Values.gateway.services.core.http.port | default "18082" }}
             {{- end }}
           env:

--- a/apim/3.x/templates/gateway/gateway-service.yaml
+++ b/apim/3.x/templates/gateway/gateway-service.yaml
@@ -34,7 +34,7 @@ spec:
       {{ end }}
       {{ end }}
       {{- end }}
-      name: {{ .Values.gateway.name }}
+      name: {{ .Values.gateway.name | trunc 63 | trimSuffix "-" }}
     {{- if .Values.gateway.services.bridge.enabled }}
     - port: {{ .Values.gateway.services.bridge.service.externalPort }}
       targetPort: {{ .Values.gateway.services.bridge.service.internalPort }}
@@ -50,7 +50,7 @@ spec:
       {{ end }}
       {{ end }}
       {{- end }}
-      name: {{ .Values.gateway.name }}-bridge
+      name: {{ printf "%s-%s" (.Values.gateway.name | trunc 56 | trimSuffix "-") "bridge" }}
     {{- end }}
     {{- if .Values.gateway.services.core.service.enabled }}
     - port: {{ .Values.gateway.services.core.service.externalPort }}
@@ -63,7 +63,7 @@ spec:
       appProtocol: http
       {{ end }}
       {{- end }}
-      name: {{ .Values.gateway.name }}-technical
+      name: {{ printf "%s-%s" (.Values.gateway.name | trunc 53 | trimSuffix "-") "technical" }}
     {{- end }}
   selector:
     app.kubernetes.io/name: {{ template "gravitee.name" . }}

--- a/apim/3.x/templates/portal/portal-service.yaml
+++ b/apim/3.x/templates/portal/portal-service.yaml
@@ -27,7 +27,7 @@ spec:
       appProtocol: http
       {{ end }}
       {{- end }}
-      name: {{ .Values.portal.name }}
+      name: {{ .Values.portal.name | trunc 63 | trimSuffix "-" }}
   selector:
     app.kubernetes.io/name: {{ template "gravitee.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/apim/3.x/templates/ui/ui-service.yaml
+++ b/apim/3.x/templates/ui/ui-service.yaml
@@ -27,7 +27,7 @@ spec:
       appProtocol: http
       {{ end }}
       {{- end }}
-      name: {{ .Values.ui.name }}
+      name: {{ .Values.ui.name | trunc 63 | trimSuffix "-" }}
   selector:
     app.kubernetes.io/name: {{ template "gravitee.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/apim/3.x/tests/api/deployment_test.yaml
+++ b/apim/3.x/tests/api/deployment_test.yaml
@@ -147,3 +147,29 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: "test-sa"
+
+  - it: Deploy with long api name
+    template: api/api-deployment.yaml
+    set:
+      api:
+        name: "I-am-a-very-long-name"
+        services:
+          bridge:
+            enabled: true
+            service:
+              externalPort: 92
+              internalPort: 18092
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].ports
+          value: 
+            - containerPort: 8083
+              name: http
+            - containerPort: 18083
+              name: I-am-a-techapi
+            - containerPort: 18092
+              name: I-am-a-v-bridge

--- a/apim/3.x/tests/api/service_test.yaml
+++ b/apim/3.x/tests/api/service_test.yaml
@@ -48,3 +48,42 @@ tests:
             protocol: TCP
             name: api
             appProtocol: http-test
+
+  - it: Deploy with long api name
+    template: api/api-service.yaml
+    set:
+      api:
+        name: "I-am-a-very-long-name-Neque-porro-quisquam-est-qui-dolorem-ipsum-quia-dolor-sit"
+        services:
+          bridge:
+            enabled: true
+            service:
+              externalPort: 42
+        http:
+          services:
+            core:
+              service:
+                enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.ports
+          value: 
+            - appProtocol: http
+              name: I-am-a-very-long-name-Neque-porro-quisquam-est-qui-dolorem-ipsu
+              port: 83
+              protocol: TCP
+              targetPort: 8083
+            - appProtocol: http
+              name: I-am-a-very-long-name-Neque-porro-quisquam-est-qui-do-technical
+              port: null
+              protocol: TCP
+              targetPort: 18083
+            - appProtocol: http
+              name: I-am-a-very-long-name-Neque-porro-quisquam-est-qui-dolor-bridge
+              port: 42
+              protocol: TCP
+              targetPort: null

--- a/apim/3.x/tests/gateway/deployment_test.yaml
+++ b/apim/3.x/tests/gateway/deployment_test.yaml
@@ -175,3 +175,34 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: "test-sa"
+
+  - it: Deploy with long api name
+    template: gateway/gateway-deployment.yaml
+    set:
+      gateway:
+        name: "I-am-a-very-long-name"
+        services:
+          bridge:
+            enabled: true
+            service:
+              externalPort: 92
+              internalPort: 18092
+          core:
+            http:
+              enabled: true
+          kubeController:
+            enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].ports
+          value: 
+            - containerPort: 8082
+              name: http
+            - containerPort: 18092
+              name: I-am-a-v-bridge
+            - containerPort: 18082
+              name: I-am-a-techapi

--- a/apim/3.x/tests/gateway/service_test.yaml
+++ b/apim/3.x/tests/gateway/service_test.yaml
@@ -48,3 +48,40 @@ tests:
             protocol: TCP
             name: gateway
             appProtocol: https
+
+  - it: Deploy with long gateway name
+    template: gateway/gateway-service.yaml
+    set:
+      gateway:
+        name: "I-am-a-very-long-name-Neque-porro-quisquam-est-qui-dolorem-ipsum-quia-dolor-sit"
+        services:
+          bridge:
+            enabled: true
+            service:
+              externalPort: 42
+          core:
+            service:
+              enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.ports
+          value: 
+            - appProtocol: http
+              name: I-am-a-very-long-name-Neque-porro-quisquam-est-qui-dolorem-ipsu
+              port: 82
+              protocol: TCP
+              targetPort: 8082
+            - appProtocol: http
+              name: I-am-a-very-long-name-Neque-porro-quisquam-est-qui-dolor-bridge
+              port: 42
+              protocol: TCP
+              targetPort: null
+            - appProtocol: http
+              name: I-am-a-very-long-name-Neque-porro-quisquam-est-qui-do-technical
+              port: null
+              protocol: TCP
+              targetPort: 18082

--- a/apim/3.x/tests/portal/service_test.yaml
+++ b/apim/3.x/tests/portal/service_test.yaml
@@ -48,3 +48,22 @@ tests:
             protocol: TCP
             name: portal
             appProtocol: http
+
+  - it: Deploy with long portal name
+    template: portal/portal-service.yaml
+    set:
+      portal:
+        name: "I-am-a-very-long-name-Neque-porro-quisquam-est-qui-dolorem-ipsum-quia-dolor-sit"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.ports
+          value: 
+            - appProtocol: http
+              name: I-am-a-very-long-name-Neque-porro-quisquam-est-qui-dolorem-ipsu
+              port: 8003
+              protocol: TCP
+              targetPort: 8080

--- a/apim/3.x/tests/ui/service_test.yaml
+++ b/apim/3.x/tests/ui/service_test.yaml
@@ -48,3 +48,22 @@ tests:
             protocol: TCP
             name: ui
             appProtocol: http
+
+  - it: Deploy with long portal name
+    template: ui/ui-service.yaml
+    set:
+      ui:
+        name: "I-am-a-very-long-name-Neque-porro-quisquam-est-qui-dolorem-ipsum-quia-dolor-sit"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.ports
+          value: 
+            - appProtocol: http
+              name: I-am-a-very-long-name-Neque-porro-quisquam-est-qui-dolorem-ipsu
+              port: 8002
+              protocol: TCP
+              targetPort: 8080

--- a/cockpit/CHANGELOG.md
+++ b/cockpit/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to [Gravitee.io Cockpit](https://github.com/gravitee-io/helm-charts/tree/master/cockpit) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 1.6.23
+
+- [X] Trunc port name with k8s limit (63)
+
 ### 1.6.22
 
 - [X] Use ISO 8601 datetime for cockpit json logging

--- a/cockpit/Chart.yaml
+++ b/cockpit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: cockpit
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 1.6.22
+version: 1.6.23
 appVersion: 3.16.0
 description: Official Gravitee.io Helm chart for Cockpit
 home: https://gravitee.io

--- a/cockpit/templates/api/api-service.yaml
+++ b/cockpit/templates/api/api-service.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   type: "{{ .Values.api.service.type }}"
   ports:
-    - name: {{ .Values.api.name }}-http
+    - name: {{ printf "%s-%s" (.Values.api.name | trunc 58 | trimSuffix "-") "http" }}
       port: {{ .Values.api.service.externalPort }}
       targetPort: {{ .Values.api.service.internalPortName }}
       protocol: TCP
@@ -33,7 +33,7 @@ spec:
       {{ end }}
       {{ end }}
     {{- if .Values.api.controller.ws.service.enabled }}
-    - name: {{ .Values.api.name }}-ws
+    - name: {{ printf "%s-%s" (.Values.api.name | trunc 60 | trimSuffix "-") "ws" }}
       port: {{ .Values.api.controller.ws.service.externalPort }}
       targetPort: {{ .Values.api.controller.ws.service.internalPortName }}
       protocol: TCP
@@ -46,7 +46,7 @@ spec:
       {{- end }}
     {{- end }}
     {{- if .Values.api.http.services.core.service.enabled }}
-    - name: {{ .Values.api.name }}-technical
+    - name: {{ printf "%s-%s" (.Values.api.name | trunc 53 | trimSuffix "-") "technical" }}
       port: {{ .Values.api.http.services.core.service.externalPort }}
       targetPort: {{ .Values.api.http.services.core.service.internalPortName }}
       protocol: TCP

--- a/cockpit/templates/generator/generator-service.yaml
+++ b/cockpit/templates/generator/generator-service.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   type: "{{ .Values.generator.service.type }}"
   ports:
-    - name: {{ .Values.generator.name }}
+    - name: {{ .Values.generator.name | trunc 63 | trimSuffix "-" }}
       port: {{ .Values.generator.service.externalPort }}
       targetPort: {{ .Values.generator.service.internalPortName }}
       protocol: TCP

--- a/cockpit/templates/ui/ui-service.yaml
+++ b/cockpit/templates/ui/ui-service.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   type: "{{ .Values.ui.service.type }}"
   ports:
-    - name: {{ .Values.ui.name }}
+    - name: {{ .Values.ui.name | trunc 63 | trimSuffix "-" }}
       port: {{ .Values.ui.service.externalPort }}
       targetPort: {{ .Values.ui.service.internalPortName }}
       protocol: TCP

--- a/cockpit/tests/api/api-service_test.yaml
+++ b/cockpit/tests/api/api-service_test.yaml
@@ -171,3 +171,40 @@ tests:
               app.kubernetes.io/component: api
               app.kubernetes.io/instance: my-cockpit
               app.kubernetes.io/name: cockpit
+
+  - it: Deploy with long api name
+    template: api/api-service.yaml
+    set:
+      api:
+        name: "I-am-a-very-long-name-Neque-porro-quisquam-est-qui-dolorem-ipsum-quia-dolor-sit"
+        controller:
+          ws:
+            enabled: true
+        http:
+          services:
+            core:
+              service:
+                enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.ports
+          value: 
+            - appProtocol: http
+              name: I-am-a-very-long-name-Neque-porro-quisquam-est-qui-dolorem-http
+              port: 8063
+              protocol: TCP
+              targetPort: api-http
+            - appProtocol: http
+              name: I-am-a-very-long-name-Neque-porro-quisquam-est-qui-dolorem-i-ws
+              port: 8062
+              protocol: TCP
+              targetPort: api-ws
+            - appProtocol: http
+              name: I-am-a-very-long-name-Neque-porro-quisquam-est-qui-do-technical
+              port: 18063
+              protocol: TCP
+              targetPort: api-technical

--- a/cockpit/tests/generator/generator-service_test.yaml
+++ b/cockpit/tests/generator/generator-service_test.yaml
@@ -104,3 +104,22 @@ tests:
               app.kubernetes.io/component: swagger-generator
               app.kubernetes.io/instance: my-cockpit
               app.kubernetes.io/name: cockpit
+
+  - it: Deploy with long generator name
+    template: generator/generator-service.yaml
+    set:
+      generator:
+        name: "I-am-a-very-long-name-Neque-porro-quisquam-est-qui-dolorem-ipsum-quia-dolor-sit"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.ports
+          value: 
+          - appProtocol: http
+            name: I-am-a-very-long-name-Neque-porro-quisquam-est-qui-dolorem-ipsu
+            port: 84
+            protocol: TCP
+            targetPort: generator-http

--- a/cockpit/tests/ui/ui-service_test.yaml
+++ b/cockpit/tests/ui/ui-service_test.yaml
@@ -104,3 +104,22 @@ tests:
               app.kubernetes.io/component: ui
               app.kubernetes.io/instance: my-cockpit
               app.kubernetes.io/name: cockpit
+
+  - it: Deploy with long api name
+    template: ui/ui-service.yaml
+    set:
+      ui:
+        name: "I-am-a-very-long-name-Neque-porro-quisquam-est-qui-dolorem-ipsum-quia-dolor-sit"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.ports
+          value: 
+          - appProtocol: http
+            name: I-am-a-very-long-name-Neque-porro-quisquam-est-qui-dolorem-ipsu
+            port: 8002
+            protocol: TCP
+            targetPort: ui-http

--- a/designer/CHANGELOG.md
+++ b/designer/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to [Gravitee.io API Designer](https://github.com/gravitee-io/helm-charts/tree/master/designer) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 1.0.14
+
+- [X] Trunc port name with k8s limit (63)
+
 ### 1.0.13
 
 - [X] Upgrade Mongodb and Elasticsearch dependencies

--- a/designer/Chart.yaml
+++ b/designer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: designer
-version: 1.0.12
+version: 1.0.14
 appVersion: 1.31.4
 description: Official Gravitee.io Helm chart for API Designer
 home: https://gravitee.io

--- a/designer/templates/api/api-service.yaml
+++ b/designer/templates/api/api-service.yaml
@@ -20,7 +20,7 @@ spec:
     - port: {{ .Values.api.service.externalPort }}
       targetPort: {{ .Values.api.service.internalPort }}
       protocol: TCP
-      name: {{ .Values.api.name }}
+      name: {{ .Values.api.name | trunc 63 | trimSuffix "-" }}
   selector:
     app.kubernetes.io/name: {{ template "gravitee.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/designer/templates/generator/generator-service.yaml
+++ b/designer/templates/generator/generator-service.yaml
@@ -20,7 +20,7 @@ spec:
     - port: {{ .Values.generator.service.externalPort }}
       targetPort: {{ .Values.generator.service.internalPort }}
       protocol: TCP
-      name: {{ .Values.generator.name }}
+      name: {{ .Values.generator.name | trunc 63 | trimSuffix "-" }}
   selector:
     app.kubernetes.io/name: {{ template "gravitee.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/designer/templates/ui/ui-service.yaml
+++ b/designer/templates/ui/ui-service.yaml
@@ -20,7 +20,7 @@ spec:
     - port: {{ .Values.ui.service.externalPort }}
       targetPort: {{ .Values.ui.service.internalPort }}
       protocol: TCP
-      name: {{ .Values.ui.name }}
+      name: {{ .Values.ui.name | trunc 63 | trimSuffix "-" }}
   selector:
     app.kubernetes.io/name: {{ template "gravitee.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8345

Followup of https://github.com/gravitee-io/helm-charts/pull/292


**Description**

Crop all ports names to ensure they have a correct size


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
