### PR TITLE
feat(cockpit): define default pod anti-affinity

### DIFF
--- a/cockpit/templates/_helpers.tpl
+++ b/cockpit/templates/_helpers.tpl
@@ -219,3 +219,60 @@ Return the appropriate apiVersion for pod autoscaling.
 {{- print "autoscaling/v2" -}}
 {{- end }}
 {{- end -}}
+
+{{/* Define default API affinity */}}
+{{- define "api.default.affinity" -}}
+podAntiAffinity:
+  preferredDuringSchedulingIgnoredDuringExecution:
+  - weight: 100
+    podAffinityTerm:
+      labelSelector:
+        matchExpressions:
+        - key: app.kubernetes.io/name
+          operator: In
+          values:
+            - {{ template "gravitee.name" . }}
+        - key: app.kubernetes.io/component
+          operator: In
+          values:
+            - {{ .Values.api.name }}
+      topologyKey: "kubernetes.io/hostname"
+{{- end }}
+
+{{/* Define default UI affinity */}}
+{{- define "ui.default.affinity" -}}
+podAntiAffinity:
+  preferredDuringSchedulingIgnoredDuringExecution:
+  - weight: 100
+    podAffinityTerm:
+      labelSelector:
+        matchExpressions:
+        - key: app.kubernetes.io/name
+          operator: In
+          values:
+            - {{ template "gravitee.name" . }}
+        - key: app.kubernetes.io/component
+          operator: In
+          values:
+            - {{ .Values.ui.name }}
+      topologyKey: "kubernetes.io/hostname"
+{{- end }}
+
+{{/* Define default Generator affinity */}}
+{{- define "generator.default.affinity" -}}
+podAntiAffinity:
+  preferredDuringSchedulingIgnoredDuringExecution:
+  - weight: 100
+    podAffinityTerm:
+      labelSelector:
+        matchExpressions:
+        - key: app.kubernetes.io/name
+          operator: In
+          values:
+            - {{ template "gravitee.name" . }}
+        - key: app.kubernetes.io/component
+          operator: In
+          values:
+            - {{ .Values.generator.name }}
+      topologyKey: "kubernetes.io/hostname"
+{{- end }}

--- a/cockpit/templates/api/api-deployment.yaml
+++ b/cockpit/templates/api/api-deployment.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.api.enabled -}}
 {{- $serviceAccount := include "cockpit.serviceAccount" . -}}
+{{- $baseAffinity := include "api.default.affinity" . | fromYaml -}}
+{{- $mergedAffinity := mustMergeOverwrite (dict) .Values.api.deployment.affinity $baseAffinity -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -67,7 +69,7 @@ spec:
       {{- if $serviceAccount }}
       serviceAccountName: {{ $serviceAccount }}
       {{ end }}
-      affinity: {{ toYaml .Values.api.deployment.affinity | nindent 8 }}
+      affinity: {{- toYaml $mergedAffinity | nindent 8 }}
       nodeSelector: {{ toYaml .Values.api.deployment.nodeSelector | nindent 8 }}
       topologySpreadConstraints: {{ toYaml .Values.api.deployment.topologySpreadConstraints | nindent 8 }}
       tolerations: {{ toYaml .Values.api.deployment.tolerations | nindent 8 }}

--- a/cockpit/templates/generator/generator-deployment.yaml
+++ b/cockpit/templates/generator/generator-deployment.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.generator.enabled -}}
 {{- $serviceAccount := include "cockpit.serviceAccount" . -}}
+{{- $baseAffinity := include "generator.default.affinity" . | fromYaml -}}
+{{- $mergedAffinity := mustMergeOverwrite (dict) .Values.generator.deployment.affinity $baseAffinity -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -62,7 +64,7 @@ spec:
       {{- if $serviceAccount }}
       serviceAccountName: {{ $serviceAccount }}
       {{ end }}
-      affinity: {{ toYaml .Values.generator.deployment.affinity | nindent 8 }}
+      affinity: {{- toYaml $mergedAffinity | nindent 8 }}
       nodeSelector: {{ toYaml .Values.generator.deployment.nodeSelector | nindent 8 }}
       topologySpreadConstraints: {{ toYaml .Values.generator.deployment.topologySpreadConstraints | nindent 8 }}
       tolerations: {{ toYaml .Values.generator.deployment.tolerations | nindent 8 }}

--- a/cockpit/templates/ui/ui-deployment.yaml
+++ b/cockpit/templates/ui/ui-deployment.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.ui.enabled -}}
+{{- $baseAffinity := include "ui.default.affinity" . | fromYaml -}}
+{{- $mergedAffinity := mustMergeOverwrite (dict) .Values.ui.deployment.affinity $baseAffinity -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -61,7 +63,7 @@ spec:
         {{- end }}
         {{- end }}
     spec:
-      affinity: {{ toYaml .Values.ui.deployment.affinity | nindent 8 }}
+      affinity: {{- toYaml $mergedAffinity | nindent 8 }}
       nodeSelector: {{ toYaml .Values.ui.deployment.nodeSelector | nindent 8 }}
       topologySpreadConstraints: {{ toYaml .Values.ui.deployment.topologySpreadConstraints | nindent 8 }}
       tolerations: {{ toYaml .Values.ui.deployment.tolerations | nindent 8 }}

--- a/cockpit/tests/api/api-deployment_test.yaml
+++ b/cockpit/tests/api/api-deployment_test.yaml
@@ -80,7 +80,22 @@ tests:
       - equal:
           path: spec.template.spec
           value:
-            affinity: {}
+            affinity:
+              podAntiAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  - weight: 100
+                    podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                          - key: app.kubernetes.io/name
+                            operator: In
+                            values:
+                              - cockpit
+                          - key: app.kubernetes.io/component
+                            operator: In
+                            values:
+                              - api
+                      topologyKey: "kubernetes.io/hostname"
             containers:
             - env: null
               envFrom: []

--- a/cockpit/tests/generator/generator-deployment_test.yaml
+++ b/cockpit/tests/generator/generator-deployment_test.yaml
@@ -80,7 +80,22 @@ tests:
       - equal:
           path: spec.template.spec
           value:
-            affinity: {}
+            affinity:
+              podAntiAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  - weight: 100
+                    podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                          - key: app.kubernetes.io/name
+                            operator: In
+                            values:
+                              - cockpit
+                          - key: app.kubernetes.io/component
+                            operator: In
+                            values:
+                              - swagger-generator
+                      topologyKey: "kubernetes.io/hostname"
             containers:
             - env: null
               envFrom: []

--- a/cockpit/tests/ui/ui-deployment_test.yaml
+++ b/cockpit/tests/ui/ui-deployment_test.yaml
@@ -80,7 +80,22 @@ tests:
       - equal:
           path: spec.template.spec
           value:
-            affinity: {}
+            affinity:
+              podAntiAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  - weight: 100
+                    podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                          - key: app.kubernetes.io/name
+                            operator: In
+                            values:
+                              - cockpit
+                          - key: app.kubernetes.io/component
+                            operator: In
+                            values:
+                              - ui
+                      topologyKey: "kubernetes.io/hostname"
             containers:
             - env:
               - name: API_URL


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/gravitee-cockpit/issues/3117

**Description**

I'm using templates to merge default affinity with provided ones if defined in `values.yml`
See: https://rm3l.org/merging-dynamic-config-data-in-helm-charts/
