### PR TITLE
rollingUpdate maxUnavailable set to 25% to avoid stop when only 1 pod…

### DIFF
--- a/am/values.yaml
+++ b/am/values.yaml
@@ -173,7 +173,7 @@ api:
   reloadOnConfigChange: true
   updateStrategy:
     rollingUpdate:
-      maxUnavailable: 1
+      maxUnavailable: 25%
     type: RollingUpdate
   replicaCount: 1
   image:
@@ -208,7 +208,7 @@ api:
     strategy:
       type: RollingUpdate
       rollingUpdate:
-        maxUnavailable: 1
+        maxUnavailable: 25%
     topologySpreadConstraints: []
     # revisionHistoryLimit: 10
 
@@ -464,7 +464,7 @@ gateway:
     strategy:
       type: RollingUpdate
       rollingUpdate:
-        maxUnavailable: 1
+        maxUnavailable: 25%
     topologySpreadConstraints: []
     # revisionHistoryLimit: 10
 
@@ -675,7 +675,7 @@ ui:
     strategy:
       type: RollingUpdate
       rollingUpdate:
-        maxUnavailable: 1
+        maxUnavailable: 25%
     topologySpreadConstraints: []
     # revisionHistoryLimit: 10
 


### PR DESCRIPTION
**Description**

Set default rolling update max unavailable to 25% (the default value) instead of 1 to avoid stop and restart if only 1 pod is available.

It's not a bug but it's a trap :). 
