### PR TITLE
APIM: Use `smtp.properties` directly instead of copying properties one by one

### DIFF
--- a/apim/3.x/CHANGELOG.md
+++ b/apim/3.x/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 3.1.55
+
+- [X] Fix: Merge all smtp.properties directly into gravitee.yml
+- [X] Fix: Enable notifiers ssl with right smtp.ssl value
+
+- **BREAKING CHANGE**: Use `smtp.properties.starttls.enable` instead of `smtp.properties.starttlsEnable`
+
 ### 3.1.54
 
 - [X] Add a startup probe on the Management API

--- a/apim/3.x/Chart.yaml
+++ b/apim/3.x/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: apim3
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 3.1.54
+version: 3.1.55
 appVersion: 3.15.10
 description: Official Gravitee.io Helm chart for API Management 3.x
 home: https://gravitee.io
@@ -20,5 +20,6 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/apim3?modal=changelog
   artifacthub.io/changes: |
-    - Add a startup probe on the Management API    
-    - Truncate port name to respect k8s limit (15 for deployment and 63 for service)
+    - Fix: Merge all smtp.properties directly into gravitee.yml
+    - Fix: Enable notifiers ssl with right smtp.ssl value
+    - BREAKING CHANGE: Use `smtp.properties.starttls.enable` instead of `smtp.properties.starttlsEnable`

--- a/apim/3.x/templates/api/api-configmap.yaml
+++ b/apim/3.x/templates/api/api-configmap.yaml
@@ -381,7 +381,7 @@ data:
         password: {{ .Values.notifiers.smtp.password }}
         {{- end }}
         starttls.enabled: {{ .Values.notifiers.smtp.starttlsEnabled | default false }}
-        {{- if .Values.smtp.ssl }}
+        {{- if .Values.notifiers.smtp.ssl }}
         ssl:
           trustAll: {{ .Values.notifiers.smtp.ssl.trustAll }}
           keyStore: {{ .Values.notifiers.smtp.ssl.keyStore }}

--- a/apim/3.x/templates/api/api-configmap.yaml
+++ b/apim/3.x/templates/api/api-configmap.yaml
@@ -361,12 +361,10 @@ data:
       username: {{ .Values.smtp.username }}
       password: {{ .Values.smtp.password }}
       {{- end }}
+      {{- with .Values.smtp.properties }}
       properties:
-        auth: {{ .Values.smtp.properties.auth }}
-        starttls.enable: {{ .Values.smtp.properties.starttlsEnable }}
-        {{- if .Values.smtp.properties.localhost }}
-        localhost: {{ .Values.smtp.properties.localhost }}
-        {{- end }}
+        {{ toYaml . | nindent 8 | trim -}}
+      {{- end }}
       {{- end }}
 
     # SMTP configuration used to send notifications / alerts

--- a/apim/3.x/tests/api/configmap_email_test.yaml
+++ b/apim/3.x/tests/api/configmap_email_test.yaml
@@ -1,0 +1,48 @@
+suite: Test Management API default configmap
+templates:
+  - "api/api-configmap.yaml"
+tests:
+  - it: Set smtp attributes
+    template: api/api-configmap.yaml
+    set:
+      smtp:
+        enabled: true
+        host: TEST.host
+        port: 4242
+        from: TEST.from
+        username: TEST.username
+        password: TEST.password
+        subject: "TEST.subject"
+        properties:
+          auth: true
+          starttls.enable: false
+          localhost: TEST.properties.localhost
+          ssl.trust: TEST.properties.ssl.trust
+    asserts:
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "host: TEST.host"
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "port: 4242"
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "from: TEST.from"
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "username: TEST.username"
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "password: TEST.password"
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "subject: \"TEST.subject\""
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "starttls.enable: false"
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "localhost: TEST.properties.localhost"
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "ssl.trust: TEST.properties.ssl.trust"

--- a/apim/3.x/tests/api/configmap_email_test.yaml
+++ b/apim/3.x/tests/api/configmap_email_test.yaml
@@ -36,7 +36,7 @@ tests:
           pattern: "password: TEST.password"
       - matchRegex:
           path: data.[gravitee.yml]
-          pattern: "subject: \"TEST.subject\""
+          pattern: 'subject: "TEST.subject"'
       - matchRegex:
           path: data.[gravitee.yml]
           pattern: "starttls.enable: false"
@@ -46,3 +46,52 @@ tests:
       - matchRegex:
           path: data.[gravitee.yml]
           pattern: "ssl.trust: TEST.properties.ssl.trust"
+
+  - it: Set notifiers smtp attributes
+    template: api/api-configmap.yaml
+    set:
+      notifiers:
+        smtp:
+          enabled: true
+          host: TEST.host
+          subject: TEST.subject
+          port: 4242
+          from: TEST.from
+          username: TEST.username
+          password: TEST.password
+          starttlsEnabled: true
+          ssl:
+            trustAll: false
+            keyStore: TEST.keyStore
+            keyStorePassword: TEST.keyStorePassword
+    asserts:
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "host: TEST.host"
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "port: 4242"
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "from: TEST.from"
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "username: TEST.username"
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "password: TEST.password"
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: 'subject: "TEST.subject"'
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "starttls.enabled: true"
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "trustAll: false"
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "keyStore: TEST.keyStore"
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "keyStorePassword: TEST.keyStorePassword"

--- a/apim/3.x/values.yaml
+++ b/apim/3.x/values.yaml
@@ -159,7 +159,6 @@ smtp:
     auth: true
     starttls.enable: false
     #localhost: apim.example.com
-    #ssl.trust: smtp.gmail.com
 
 notifiers:
   smtp:

--- a/apim/3.x/values.yaml
+++ b/apim/3.x/values.yaml
@@ -157,8 +157,9 @@ smtp:
   subject: "[gravitee] %s"
   properties:
     auth: true
-    starttlsEnable: false
+    starttls.enable: false
     #localhost: apim.example.com
+    #ssl.trust: smtp.gmail.com
 
 notifiers:
   smtp:


### PR DESCRIPTION
**Description**


Reapply https://github.com/gravitee-io/helm-charts/pull/299 with a breaking change to ensure the generated config-map is ok.

BREAKING CHANGE: Use `smtp.properties.starttls.enable` instead of `smtp.properties.starttlsEnable`

