### PR TITLE
Cockpit hazelcast override

### DIFF
--- a/cockpit/CHANGELOG.md
+++ b/cockpit/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 This file documents all notable changes to [Gravitee.io Cockpit](https://github.com/gravitee-io/helm-charts/tree/master/cockpit) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
-### 1.6.23
-
+### 1.7.0
 - [X] Trunc port name with k8s limit (63)
+- [X] Define default pod anti-affinity
+- [X] Enable INFO logs for Hazelcast
+- [X] Create new configmap to generate yaml config for Hazelcast
 
 ### 1.6.22
 

--- a/cockpit/Chart.yaml
+++ b/cockpit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: cockpit
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 1.6.23
+version: 1.7.0
 appVersion: 3.16.0
 description: Official Gravitee.io Helm chart for Cockpit
 home: https://gravitee.io
@@ -21,4 +21,7 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/cockpit?modal=changelog
   artifacthub.io/changes: |
-    - Use ISO 8601 datetime for cockpit json logging
+    - Trunc port name with k8s limit (63)
+    - Define default pod anti-affinity
+    - Enable INFO logs for Hazelcast
+    - Create new configmap to generate yaml config for Hazelcast

--- a/cockpit/templates/api/api-configmap.yaml
+++ b/cockpit/templates/api/api-configmap.yaml
@@ -249,6 +249,47 @@ data:
         </network>
     </hazelcast>
 
+  hazelcast.yml: |
+    hazelcast:
+      cluster-name: {{ .Release.Name }}_{{ .Release.Revision }}
+      network:
+        join:
+          multicast:
+            enabled: false
+          tcp-ip:
+            enabled: false
+          kubernetes:
+            enabled: true
+            namespace: {{ .Release.Namespace }}
+            service-name: {{ template "gravitee.api.fullname" . }}
+
+{{- if .Values.hazelcast.advancedNetwork }}
+      advanced-network:
+        {{- toYaml .Values.hazelcast.advancedNetwork | nindent 8 }}
+{{- end }}
+
+      properties:
+        hazelcast.logging.type: slf4j
+        hazelcast.max.wait.seconds.before.join: 3
+        hazelcast.member.list.publish.interval.seconds: 5
+        hazelcast.socket.client.bind.any: false
+{{- if .Values.hazelcast.properties }}
+        {{- toYaml .Values.hazelcast.properties | nindent 8 }}
+{{- end }}
+
+      cp-subsystem:
+        cp-member-count: 0
+      map:
+        cockpit.channels.*:
+          backup-count: 0
+          async-backup-count: 1
+      queue:
+        commands-*:
+          backup-count: 0
+          async-backup-count: 1
+      reliable-topic:
+        cockpit.primaryChannels:
+          read-batch-size: 10
 
   logback.xml: |
     <?xml version="1.0" encoding="UTF-8"?>

--- a/cockpit/templates/api/api-configmap.yaml
+++ b/cockpit/templates/api/api-configmap.yaml
@@ -301,6 +301,7 @@ data:
             <logger name="io.gravitee" level="{{ .Values.api.logging.graviteeLevel }}" />
             <logger name="com.graviteesource" level="{{ .Values.api.logging.graviteeLevel }}" />
             <logger name="org.eclipse.jetty" level="{{ .Values.api.logging.jettyLevel }}" />
+            <logger name="com.hazelcast" level="INFO"/>
 {{- if .Values.api.logging.additionalLoggers }}
 {{ .Values.api.logging.additionalLoggers | indent 12 }}
 {{- end }}

--- a/cockpit/templates/api/api-deployment.yaml
+++ b/cockpit/templates/api/api-deployment.yaml
@@ -142,6 +142,9 @@ spec:
               mountPath: /opt/gravitee-cockpit-management-api/config/hazelcast.xml
               subPath: hazelcast.xml
             - name: config
+              mountPath: /opt/gravitee-cockpit-management-api/config/hazelcast.yml
+              subPath: hazelcast.yml
+            - name: config
               mountPath: /opt/gravitee-cockpit-management-api/config/logback.xml
               subPath: logback.xml
           {{- include "deployment.pluginVolumeMounts" $pluginParams | indent 12 }}

--- a/cockpit/tests/api/api-configmap_hazelcast_yaml_test.yaml
+++ b/cockpit/tests/api/api-configmap_hazelcast_yaml_test.yaml
@@ -93,3 +93,118 @@ tests:
                     </join>
                 </network>
             </hazelcast>
+
+  - it: should apply default hazelcast.yml configuration
+    template: api/api-configmap.yaml
+    release:
+      name: my-cockpit
+      namespace: unittest
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: data.[hazelcast.yml]
+          value: |
+            hazelcast:
+              cluster-name: my-cockpit_0
+              network:
+                join:
+                  multicast:
+                    enabled: false
+                  tcp-ip:
+                    enabled: false
+                  kubernetes:
+                    enabled: true
+                    namespace: unittest
+                    service-name: my-cockpit-api
+
+              properties:
+                hazelcast.logging.type: slf4j
+                hazelcast.max.wait.seconds.before.join: 3
+                hazelcast.member.list.publish.interval.seconds: 5
+                hazelcast.socket.client.bind.any: false
+
+              cp-subsystem:
+                cp-member-count: 0
+              map:
+                cockpit.channels.*:
+                  backup-count: 0
+                  async-backup-count: 1
+              queue:
+                commands-*:
+                  backup-count: 0
+                  async-backup-count: 1
+              reliable-topic:
+                cockpit.primaryChannels:
+                  read-batch-size: 10
+
+  - it: should apply additional properties in hazelcast.yml configuration
+    template: api/api-configmap.yaml
+    set:
+      hazelcast:
+        properties:
+          hazelcast.diagnostics.enabled: true
+        advancedNetwork:
+          enabled: true
+          rest-server-socket-endpoint-config:
+            endpoint-groups:
+              CLUSTER_READ:
+                enabled: true
+              HEALTH_CHECK:
+                enabled: true
+    release:
+      name: my-cockpit
+      namespace: unittest
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: data.[hazelcast.yml]
+          value: |
+            hazelcast:
+              cluster-name: my-cockpit_0
+              network:
+                join:
+                  multicast:
+                    enabled: false
+                  tcp-ip:
+                    enabled: false
+                  kubernetes:
+                    enabled: true
+                    namespace: unittest
+                    service-name: my-cockpit-api
+              advanced-network:
+                enabled: true
+                rest-server-socket-endpoint-config:
+                  endpoint-groups:
+                    CLUSTER_READ:
+                      enabled: true
+                    HEALTH_CHECK:
+                      enabled: true
+
+              properties:
+                hazelcast.logging.type: slf4j
+                hazelcast.max.wait.seconds.before.join: 3
+                hazelcast.member.list.publish.interval.seconds: 5
+                hazelcast.socket.client.bind.any: false
+                hazelcast.diagnostics.enabled: true
+
+              cp-subsystem:
+                cp-member-count: 0
+              map:
+                cockpit.channels.*:
+                  backup-count: 0
+                  async-backup-count: 1
+              queue:
+                commands-*:
+                  backup-count: 0
+                  async-backup-count: 1
+              reliable-topic:
+                cockpit.primaryChannels:
+                  read-batch-size: 10

--- a/cockpit/tests/api/api-configmap_logback_yaml_test.yaml
+++ b/cockpit/tests/api/api-configmap_logback_yaml_test.yaml
@@ -44,6 +44,7 @@ tests:
                     <logger name="io.gravitee" level="INFO" />
                     <logger name="com.graviteesource" level="INFO" />
                     <logger name="org.eclipse.jetty" level="INFO" />
+                    <logger name="com.hazelcast" level="INFO"/>
 
                     <!-- Strictly speaking, the level attribute is not necessary since -->
                     <!-- the level of the root level is set to DEBUG by default.       -->
@@ -103,6 +104,7 @@ tests:
                     <logger name="io.gravitee" level="INFO" />
                     <logger name="com.graviteesource" level="INFO" />
                     <logger name="org.eclipse.jetty" level="INFO" />
+                    <logger name="com.hazelcast" level="INFO"/>
 
                     <!-- Strictly speaking, the level attribute is not necessary since -->
                     <!-- the level of the root level is set to DEBUG by default.       -->

--- a/cockpit/tests/api/api-deployment_test.yaml
+++ b/cockpit/tests/api/api-deployment_test.yaml
@@ -71,7 +71,7 @@ tests:
           value:
             annotations:
               chaos.alpha.kubernetes.io/enabled: "false"
-              checksum/config: 156c05267fdd50837b1a3d73cfe7d6113ac56a2371d45637e8c36b41e1b75d3c
+              checksum/config: cdabe2bcaee6b67e79211423b1d1b689edbbd4f8ccf971b2e8de9f1bd91a2d14
             labels:
               app.kubernetes.io/component: api
               app.kubernetes.io/instance: my-cockpit
@@ -138,6 +138,9 @@ tests:
               - mountPath: /opt/gravitee-cockpit-management-api/config/hazelcast.xml
                 name: config
                 subPath: hazelcast.xml
+              - mountPath: /opt/gravitee-cockpit-management-api/config/hazelcast.yml
+                name: config
+                subPath: hazelcast.yml
               - mountPath: /opt/gravitee-cockpit-management-api/config/logback.xml
                 name: config
                 subPath: logback.xml

--- a/cockpit/values.yaml
+++ b/cockpit/values.yaml
@@ -114,6 +114,10 @@ mongodb-replicaset:
       - ReadWriteOnce
     size: 1Gi
 
+hazelcast: {}
+#  advancedNetwork: {}
+#  properties: {}
+
 api:
   enabled: true
   name: api


### PR DESCRIPTION
**Description**

Generate a new configmap to configure Hazelcast with a Yaml file

This config can be used by setting the env var

```
- name: cluster_hazelcast_config_path
  value: /opt/gravitee-cockpit-management-api/config/hazelcast.yml
```

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
