### PR TITLE
fix: quote apim ui version in deployment spec labels

### DIFF
--- a/apim/3.x/templates/api/api-deployment.yaml
+++ b/apim/3.x/templates/api/api-deployment.yaml
@@ -53,7 +53,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "gravitee.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/version: {{ default .Chart.AppVersion .Values.api.image.tag }}
+        app.kubernetes.io/version: {{ default .Chart.AppVersion .Values.api.image.tag | quote }}
         app.kubernetes.io/component: "{{ .Values.api.name }}"
         {{- if .Values.api.deployment.labels }}
         {{- range $key, $value := .Values.api.deployment.labels }}

--- a/apim/3.x/templates/gateway/gateway-deployment.yaml
+++ b/apim/3.x/templates/gateway/gateway-deployment.yaml
@@ -60,7 +60,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "gravitee.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/version: {{ default .Chart.AppVersion .Values.gateway.image.tag }}
+        app.kubernetes.io/version: {{ default .Chart.AppVersion .Values.gateway.image.tag | quote }}
         app.kubernetes.io/component: "{{ .Values.gateway.name }}"
         {{- if .Values.gateway.deployment.labels }}
         {{- range $key, $value := .Values.gateway.deployment.labels }}

--- a/apim/3.x/templates/portal/portal-deployment.yaml
+++ b/apim/3.x/templates/portal/portal-deployment.yaml
@@ -46,7 +46,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "gravitee.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/version: {{ default .Chart.AppVersion .Values.portal.image.tag }}
+        app.kubernetes.io/version: {{ default .Chart.AppVersion .Values.portal.image.tag | quote }}
         app.kubernetes.io/component: "{{ .Values.portal.name }}"
         {{- if .Values.portal.deployment.labels }}
         {{- range $key, $value := .Values.portal.deployment.labels }}

--- a/apim/3.x/templates/ui/ui-deployment.yaml
+++ b/apim/3.x/templates/ui/ui-deployment.yaml
@@ -49,7 +49,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "gravitee.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/version: {{ default .Chart.AppVersion .Values.ui.image.tag }}
+        app.kubernetes.io/version: {{ default .Chart.AppVersion .Values.ui.image.tag  | quote }}
         app.kubernetes.io/component: "{{ .Values.ui.name }}"
         {{- if .Values.ui.deployment.labels }}
         {{- range $key, $value := .Values.ui.deployment.labels }}


### PR DESCRIPTION
**Description**

An error can occurs when a user tries to install apim with the 3.19 ui tag. It's considered as a number but the labels can only use strings

Current error:

<img width="1632" alt="Screenshot 2022-09-19 at 12 17 26" src="https://user-images.githubusercontent.com/25704259/190996693-f1f7b6df-c010-4815-bdbf-8fead50a7f55.png">
