### PR TITLE
variabilize the keepalive and timeouts for the connection to bridge

### DIFF
--- a/apim/3.x/templates/gateway/gateway-configmap.yaml
+++ b/apim/3.x/templates/gateway/gateway-configmap.yaml
@@ -95,9 +95,9 @@ data:
       {{- else if (eq .Values.management.type "http") }}
       http:
         url: {{ .Values.gateway.management.http.url }}
-        keepAlive: true
-        idleTimeout: 30000
-        connectTimeout: 10000
+        keepAlive: {{ .Values.gateway.management.http.keepAlive | default true }}
+        idleTimeout: {{ .Values.gateway.management.http.idleTimeout | default 30000 }}
+        connectTimeout: {{ .Values.gateway.management.http.connectTimeout | default 10000 }}
         {{- if .Values.gateway.management.http.proxy }}
         proxy:
           host: {{ .Values.gateway.management.http.proxy.host }}

--- a/apim/3.x/values.yaml
+++ b/apim/3.x/values.yaml
@@ -760,6 +760,9 @@ gateway:
   management: 
     http:
       # url: 
+      # keepAlive: true
+      # idleTimeout: 30000
+      # connectTimeout: 10000
       # username: 
       # password:
       # proxy:


### PR DESCRIPTION

**Description**

variabilize the keepalive and timeouts in the gateway's configmap template for the connection to bridge 
