### PR TITLE
fix(cockpit): generate hazelcast cluster name using the sha of the tag

### DIFF
--- a/cockpit/CHANGELOG.md
+++ b/cockpit/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file documents all notable changes to [Gravitee.io Cockpit](https://github.com/gravitee-io/helm-charts/tree/master/cockpit) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 1.7.1
+- [X] Generate hazelcast cluster name using the sha of the tag
+
 ### 1.7.0
 - [X] Trunc port name with k8s limit (63)
 - [X] Define default pod anti-affinity

--- a/cockpit/Chart.yaml
+++ b/cockpit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: cockpit
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 1.7.0
+version: 1.7.1
 appVersion: 3.16.0
 description: Official Gravitee.io Helm chart for Cockpit
 home: https://gravitee.io
@@ -21,7 +21,4 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/cockpit?modal=changelog
   artifacthub.io/changes: |
-    - Trunc port name with k8s limit (63)
-    - Define default pod anti-affinity
-    - Enable INFO logs for Hazelcast
-    - Create new configmap to generate yaml config for Hazelcast
+    - Generate hazelcast cluster name using the sha of the tag

--- a/cockpit/templates/api/api-configmap.yaml
+++ b/cockpit/templates/api/api-configmap.yaml
@@ -1,4 +1,10 @@
 {{- if .Values.api.enabled -}}
+
+{{- $clusterversion := default "0" .Release.Revision | toString -}}
+{{- if eq $clusterversion "1"  -}}
+  {{- $clusterversion = .Values.api.image.tag | default .Chart.AppVersion | sha1sum | substr 0 8 -}}
+{{- end -}}
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -251,7 +257,7 @@ data:
 
   hazelcast.yml: |
     hazelcast:
-      cluster-name: {{ .Release.Name }}_{{ .Release.Revision }}
+      cluster-name: {{ .Release.Name }}_{{ $clusterversion }}
       network:
         join:
           multicast:

--- a/cockpit/tests/api/api-configmap_hazelcast_yaml_test.yaml
+++ b/cockpit/tests/api/api-configmap_hazelcast_yaml_test.yaml
@@ -94,11 +94,12 @@ tests:
                 </network>
             </hazelcast>
 
-  - it: should apply default hazelcast.yml configuration
+  - it: should apply default hazelcast.yml configuration on the 1st revision
     template: api/api-configmap.yaml
     release:
       name: my-cockpit
       namespace: unittest
+      revision: 1
     chart:
       version: 1.0.0-chart
       appVersion: 1.0.0-app
@@ -109,7 +110,55 @@ tests:
           path: data.[hazelcast.yml]
           value: |
             hazelcast:
-              cluster-name: my-cockpit_0
+              cluster-name: my-cockpit_52359412
+              network:
+                join:
+                  multicast:
+                    enabled: false
+                  tcp-ip:
+                    enabled: false
+                  kubernetes:
+                    enabled: true
+                    namespace: unittest
+                    service-name: my-cockpit-api
+
+              properties:
+                hazelcast.logging.type: slf4j
+                hazelcast.max.wait.seconds.before.join: 3
+                hazelcast.member.list.publish.interval.seconds: 5
+                hazelcast.socket.client.bind.any: false
+
+              cp-subsystem:
+                cp-member-count: 0
+              map:
+                cockpit.channels.*:
+                  backup-count: 0
+                  async-backup-count: 1
+              queue:
+                commands-*:
+                  backup-count: 0
+                  async-backup-count: 1
+              reliable-topic:
+                cockpit.primaryChannels:
+                  read-batch-size: 10
+
+  - it: should apply default hazelcast.yml configuration on a 2nd revision
+    template: api/api-configmap.yaml
+    release:
+      name: my-cockpit
+      namespace: unittest
+      revision: 2
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: data.[hazelcast.yml]
+          value: |
+            hazelcast:
+              cluster-name: my-cockpit_2
               network:
                 join:
                   multicast:


### PR DESCRIPTION
**Issue**
https://graviteedevops.atlassian.net/browse/COC-57

**Description**

With ArgoCD, the revision number will be always 1. In that case we will generate a unique cluster name using the SHA1 of the tag

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
