### PR TITLE
Adding note about roles and namespaces

### DIFF
--- a/am/README.adoc
+++ b/am/README.adoc
@@ -111,7 +111,7 @@ mongo:
 ====
 If you need to access a secret, you have to create a role within your namespace.
 
-If you need to access a secret in another namespace, you have to create a role in that namespace. The two roles can have the same name, but they are completely seperate objects.
+If you are deploying in another namespace and you need to access a secret there, you have to create a separate role in that namespace. The two roles can have the same name, but they are completely separate objects - each role only gives access to the namespace it is created in.
 ====
 
 ==== Shared configuration

--- a/am/README.adoc
+++ b/am/README.adoc
@@ -107,6 +107,13 @@ mongo:
   uri: kubernetes://default/secrets/mongo/mongouri
 ----
 
+[TIP]
+====
+If you need to access a secret, you have to create a role within your namespace.
+
+If you need to access a secret in another namespace, you have to create a role in that namespace. The two roles can have the same name, but they are completely seperate objects.
+====
+
 ==== Shared configuration
 
 To configure common features such as:

--- a/am/README.adoc
+++ b/am/README.adoc
@@ -112,6 +112,8 @@ mongo:
 If you need to access a secret, you have to create a role within your namespace.
 
 If you are deploying in another namespace and you need to access a secret there, you have to create a separate role in that namespace. The two roles can have the same name, but they are completely separate objects - each role only gives access to the namespace it is created in.
+
+For more information about roles, see link:https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole[Role and ClusterRole] in the link:https://kubernetes.io/docs/[Kubernetes documentation].
 ====
 
 ==== Shared configuration

--- a/am/README.md
+++ b/am/README.md
@@ -63,6 +63,9 @@ mongo:
   uri: kubernetes://default/secrets/mongo/mongouri
 ```
 
+If you need to access a secret, you have to create a role within your namespace.
+
+If you need to access a secret in another namespace, you have to create a role in that namespace. The two roles can have the same name, but they are completely seperate objects.
 
 ### Shared configuration
 

--- a/am/README.md
+++ b/am/README.md
@@ -65,7 +65,9 @@ mongo:
 
 If you need to access a secret, you have to create a role within your namespace.
 
-If you need to access a secret in another namespace, you have to create a role in that namespace. The two roles can have the same name, but they are completely seperate objects.
+If you are deploying in another namespace and you need to access a secret there, you have to create a separate role in that namespace. The two roles can have the same name, but they are completely separate objects - each role only gives access to the namespace it is created in.
+
+For more information about roles, see [Role and ClusterRole](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole) in the [Kubernetes documentation](https://kubernetes.io/docs/).
 
 ### Shared configuration
 

--- a/apim/3.x/README.adoc
+++ b/apim/3.x/README.adoc
@@ -115,7 +115,9 @@ mongo:
 ====
 If you need to access a secret, you have to create a role within your namespace.
 
-If you need to access a secret in another namespace, you have to create a role in that namespace. The two roles can have the same name, but they are completely seperate objects.
+If you are deploying in another namespace and you need to access a secret there, you have to create a separate role in that namespace. The two roles can have the same name, but they are completely separate objects - each role only gives access to the namespace it is created in.
+
+For more information about roles, see link:https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole[Role and ClusterRole] in the link:https://kubernetes.io/docs/[Kubernetes documentation].
 ====
 
 

--- a/apim/3.x/README.adoc
+++ b/apim/3.x/README.adoc
@@ -111,6 +111,14 @@ mongo:
   uri: kubernetes://default/secrets/mongo/mongouri
 ----
 
+[TIP]
+====
+If you need to access a secret, you have to create a role within your namespace.
+
+If you need to access a secret in another namespace, you have to create a role in that namespace. The two roles can have the same name, but they are completely seperate objects.
+====
+
+
 ==== Shared Configuration
 
 To configure common features such as:

--- a/apim/3.x/README.md
+++ b/apim/3.x/README.md
@@ -68,7 +68,9 @@ mongo:
 
 If you need to access a secret, you have to create a role within your namespace.
 
-If you need to access a secret in another namespace, you have to create a role in that namespace. The two roles can have the same name, but they are completely seperate objects.
+If you are deploying in another namespace and you need to access a secret there, you have to create a separate role in that namespace. The two roles can have the same name, but they are completely separate objects - each role only gives access to the namespace it is created in.
+
+For more information about roles, see [Role and ClusterRole](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole) in the [Kubernetes documentation](https://kubernetes.io/docs/).
 
 ### Shared configuration
 

--- a/apim/3.x/README.md
+++ b/apim/3.x/README.md
@@ -66,6 +66,10 @@ mongo:
   uri: kubernetes://default/secrets/mongo/mongouri
 ```
 
+If you need to access a secret, you have to create a role within your namespace.
+
+If you need to access a secret in another namespace, you have to create a role in that namespace. The two roles can have the same name, but they are completely seperate objects.
+
 ### Shared configuration
 
 To configure common features such as:


### PR DESCRIPTION
**Issue**

https://graviteedevops.atlassian.net/browse/DOC-293

**Description**

I added a note about using secrets and namespaces to the APIM and AM `README.*` files. The `adocc` files are `include`d in pages on the docs site. The note was added to the `md` files as well to keep them in sync.
