### PR TITLE
feat(apim): added option to define tracing inside of ConfigMap

### DIFF
--- a/apim/3.x/templates/gateway/gateway-configmap.yaml
+++ b/apim/3.x/templates/gateway/gateway-configmap.yaml
@@ -336,6 +336,16 @@ data:
         {{- end }}
       {{- end }}
 
+      {{- if .Values.gateway.services.tracing.enabled }}
+      tracing:
+        enabled: {{ .Values.gateway.services.tracing.enabled }}
+        type: {{ .Values.gateway.services.tracing.type | quote }}
+        {{- if .Values.gateway.services.tracing.jaeger }}
+        jaeger:
+{{ toYaml .Values.gateway.services.tracing.jaeger | indent 10 }}
+        {{- end }}
+      {{- end }}
+
     {{- if or .Values.gateway.handlers }}
     handlers:
 {{ toYaml .Values.gateway.handlers | indent 6 }}

--- a/apim/3.x/tests/gateway/configmap_tracing_test.yaml
+++ b/apim/3.x/tests/gateway/configmap_tracing_test.yaml
@@ -1,0 +1,81 @@
+suite: Test Management API configmap with tracining enabled
+templates:
+  - "gateway/gateway-configmap.yaml"
+tests:
+  - it: Enable jaeger tracing
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        services:
+          tracing:
+            enabled: true
+            type: jaeger
+    asserts:
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: " * tracing:\n
+                     *  enabled: true"
+  - it: Enable jaeger tracing and set common values
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        services:
+          tracing:
+            enabled: true
+            type: jaeger
+            jaeger:
+              host: localhost
+              port: 14250
+    asserts:
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: " * tracing:\n
+                     *  enabled: true\n
+                     *  type: \"jaeger\"\n
+                     *  jaeger:\n
+                     *    host: localhost\n
+                     *    port: 14250"
+  - it: Enable jaeger tracing and set ssl values
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        services:
+          tracing:
+            enabled: true
+            type: jaeger
+            jaeger:
+              host: some-remote.host.com
+              port: 14222
+              ssl:
+                enabled: true
+                trustall: false
+                verifyHostname: true
+                keystore:
+                  password: "password-key"
+                  path: "/keystore"
+                  type: "jks"
+                truststore:
+                  password: "password-trust"
+                  path: "/truststore"
+                  type: "pem"
+    asserts:
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: " * tracing:\n
+                     *  enabled: true\n
+                     *  type: \"jaeger\"\n
+                     *  jaeger:\n
+                     *    host: some-remote.host.com\n
+                     *    port: 14222\n
+                     *    ssl:\n
+                     *      enabled: true\n
+                     *      keystore:\n
+                     *        password: password-key\n
+                     *        path: /keystore\n
+                     *        type: jks\n
+                     *      trustall: false\n
+                     *      truststore:\n
+                     *        password: password-trust\n
+                     *        path: /truststore\n
+                     *        type: pem\n
+                     *      verifyHostname: true"

--- a/apim/3.x/values.yaml
+++ b/apim/3.x/values.yaml
@@ -860,6 +860,27 @@ gateway:
       enabled: false
       prometheus:
         enabled: true
+    tracing:
+      enabled: false
+      type: jaeger
+      # see https://github.com/gravitee-io/gravitee-tracer-jaeger for docs
+      jaeger:
+        host: localhost
+        port: 14250
+        # ssl:
+        #   enabled: false
+        #   trustall: false
+        #   verifyHostname: true
+        #   keystore:
+        #     # Supports jks, pem, pkcs12
+        #     type: ""
+        #     path: ""
+        #     password: ""
+        #   truststore:
+        #     # Supports jks, pem, pkcs12
+        #     type: ""
+        #     path: ""
+        #     password: ""
 
     sync:
       cron: "*/5 * * * * *"


### PR DESCRIPTION
**Description**

I added values to define tracing options according to https://docs.gravitee.io/apim/3.x/apim_enable_opentracing_with_jaeger.html as well as the corresponding definition inside the configmap.