### PR TITLE
fix(apim): avoid null value for ae configuration

### DIFF
--- a/am/CHANGELOG.md
+++ b/am/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to [Gravitee.io Access Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/am/) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 1.0.54
+
+- [X] Fix AE alerts configuration without options
+
 ### 1.0.53
 
 - [X] Allow users to define their own configuration file by defining a volume

--- a/am/Chart.yaml
+++ b/am/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: am
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 1.0.53
+version: 1.0.54
 appVersion: 3.18.6
 description: Official Gravitee.io Helm chart for Access Management
 home: https://gravitee.io
@@ -23,4 +23,4 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/am?modal=changelog
   artifacthub.io/changes: |
-    - Allow users to define their own configuration file by defining a volume
+    - Fix AE alerts configuration without options

--- a/am/templates/api/api-configmap.yaml
+++ b/am/templates/api/api-configmap.yaml
@@ -411,7 +411,9 @@ data:
         {{- end }}        
         ws:
           discovery: true
+          {{- if .Values.alerts.options }}
           {{ toYaml .Values.alerts.options | nindent 10 | trim -}}
+          {{- end }}
           {{- with .Values.alerts.endpoints }}
           endpoints:
             {{ toYaml . | nindent 12 | trim -}}

--- a/am/templates/gateway/gateway-configmap.yaml
+++ b/am/templates/gateway/gateway-configmap.yaml
@@ -378,7 +378,9 @@ data:
         {{- end }}
         ws:
           discovery: true
+          {{- if .Values.alerts.options }}
           {{ toYaml .Values.alerts.options | nindent 10 | trim -}}
+          {{- end }}
           {{- with .Values.alerts.endpoints }}
           endpoints:
             {{ toYaml . | nindent 12 | trim -}}

--- a/apim/3.x/CHANGELOG.md
+++ b/apim/3.x/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 3.1.61
+
+- [X] Fix AE alerts configuration without options
+
 ### 3.1.60
 
 - [X] Add upgrader framework job

--- a/apim/3.x/Chart.yaml
+++ b/apim/3.x/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: apim3
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 3.1.60
+version: 3.1.61
 appVersion: 3.18.10
 description: Official Gravitee.io Helm chart for API Management 3.x
 home: https://gravitee.io
@@ -20,10 +20,4 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/apim3?modal=changelog
   artifacthub.io/changes: |
-    - Add upgrader framework job
-    - Add additional Alert Engine configuration
-    - Add additional logback loggers configuration
-    - Clean Redis configuration in the `values.yaml` file
-    - Add documentation for alert engine connector ssl
-    - Add AE engine list support
-    - Allow users to define their own configuration file by defining a volume
+    - Fix AE alerts configuration without options

--- a/apim/3.x/templates/api/api-configmap.yaml
+++ b/apim/3.x/templates/api/api-configmap.yaml
@@ -461,7 +461,9 @@ data:
         {{- end }}
         ws:
           discovery: true
+          {{- if .Values.alerts.options }}
           {{ toYaml .Values.alerts.options | nindent 10 | trim -}}
+          {{- end }}
           {{- with .Values.alerts.endpoints }}
           endpoints:
             {{ toYaml . | nindent 12 | trim -}}

--- a/apim/3.x/templates/gateway/gateway-configmap.yaml
+++ b/apim/3.x/templates/gateway/gateway-configmap.yaml
@@ -374,7 +374,9 @@ data:
         {{- end }}
         ws:
           discovery: true
+          {{- if .Values.alerts.options }}
           {{ toYaml .Values.alerts.options | nindent 10 | trim -}}
+          {{- end }}
           {{- with .Values.alerts.endpoints }}
           endpoints:
             {{ toYaml . | nindent 12 | trim -}}


### PR DESCRIPTION
Avoid null value when configuring ae without alerts.option