### PR TITLE
Add `labels` in the metrics config of the Management API and Gateway

### DIFF
--- a/apim/3.x/CHANGELOG.md
+++ b/apim/3.x/CHANGELOG.md
@@ -6,6 +6,7 @@ This file documents all notable changes to [Gravitee.io API Management 3.x](http
 ### 3.1.62
 
 - [X] Remove `/gateway` from the gateway ingress path 
+- [X] Add `labels` in metrics config of the Management API and Gateway
 
 ### 3.1.61
 

--- a/apim/3.x/Chart.yaml
+++ b/apim/3.x/Chart.yaml
@@ -21,3 +21,4 @@ annotations:
   # https://artifacthub.io/packages/helm/graviteeio/apim3?modal=changelog
   artifacthub.io/changes: |
     - Remove `/gateway` from the gateway ingress path
+    - Add `labels` in metrics config of the Management API and Gateway

--- a/apim/3.x/templates/api/api-configmap.yaml
+++ b/apim/3.x/templates/api/api-configmap.yaml
@@ -140,12 +140,7 @@ data:
       {{- end }}
 
       {{- if .Values.api.services.metrics.enabled }}
-      metrics:
-        enabled: {{ .Values.api.services.metrics.enabled }}
-        {{- if .Values.api.services.metrics.prometheus }}
-        prometheus:
-{{ toYaml .Values.api.services.metrics.prometheus | indent 10 }}
-        {{- end }}
+      metrics: {{- toYaml .Values.api.services.metrics | nindent 10 }}
       {{- end }}
       {{- if .Values.api.services.subscription.enabled }}
       subscription:

--- a/apim/3.x/templates/gateway/gateway-configmap.yaml
+++ b/apim/3.x/templates/gateway/gateway-configmap.yaml
@@ -328,12 +328,7 @@ data:
       {{- end }}
 
       {{- if .Values.gateway.services.metrics.enabled }}
-      metrics:
-        enabled: {{ .Values.gateway.services.metrics.enabled }}
-        {{- if .Values.gateway.services.metrics.prometheus }}
-        prometheus:
-{{ toYaml .Values.gateway.services.metrics.prometheus | indent 10 }}
-        {{- end }}
+      metrics: {{- toYaml .Values.gateway.services.metrics | nindent 10 }}
       {{- end }}
 
       {{- if .Values.gateway.services.tracing.enabled }}

--- a/apim/3.x/tests/api/configmap_metrics_test.yaml
+++ b/apim/3.x/tests/api/configmap_metrics_test.yaml
@@ -1,0 +1,48 @@
+suite: Test Management API default configmap - Metrics
+templates:
+  - "api/api-configmap.yaml"
+tests:
+  - it: Disable metrics service by default
+    template: api/api-configmap.yaml
+    asserts:
+      - notMatchRegex:
+          path: data.[gravitee.yml]
+          pattern: "metrics:\n"
+  - it: Enable metrics service and set `labels`
+    template: api/api-configmap.yaml
+    set:
+      api:
+        services:
+          metrics:
+            enabled: true
+            labels:
+              - local
+              - remote
+            prometheus:
+              enabled: true
+    asserts:
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: " *metrics:\n
+                     *  enabled: true\n
+                     *  labels:\n
+                     *    - local\n
+                     *    - remote\n
+                     *  prometheus:\n
+                     *    enabled: true"
+  - it: Enable metrics service and don't set any `labels`
+    template: api/api-configmap.yaml
+    set:
+      api:
+        services:
+          metrics:
+            enabled: true
+            prometheus:
+              enabled: true
+    asserts:
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: " *metrics:\n
+                     *  enabled: true\n
+                     *  prometheus:\n
+                     *    enabled: true"

--- a/apim/3.x/tests/gateway/configmap_metrics_test.yaml
+++ b/apim/3.x/tests/gateway/configmap_metrics_test.yaml
@@ -1,0 +1,48 @@
+suite: Test Gateway default configmap - Metrics
+templates:
+  - "gateway/gateway-configmap.yaml"
+tests:
+  - it: Disable metrics service by default
+    template: gateway/gateway-configmap.yaml
+    asserts:
+      - notMatchRegex:
+          path: data.[gravitee.yml]
+          pattern: "metrics:\n"
+  - it: Enable metrics service and set `labels`
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        services:
+          metrics:
+            enabled: true
+            labels:
+              - local
+              - remote
+            prometheus:
+              enabled: true
+    asserts:
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: " *metrics:\n
+                     *  enabled: true\n
+                     *  labels:\n
+                     *    - local\n
+                     *    - remote\n
+                     *  prometheus:\n
+                     *    enabled: true"
+  - it: Enable metrics service and don't set any `labels`
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        services:
+          metrics:
+            enabled: true
+            prometheus:
+              enabled: true
+    asserts:
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: " *metrics:\n
+                     *  enabled: true\n
+                     *  prometheus:\n
+                     *    enabled: true"


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7927

**Description**

Add `labels` in the metrics config of the Management API and Gateway