### PR TITLE
feat: add rate limit remote cache timeout configuration

### DIFF
--- a/apim/3.x/CHANGELOG.md
+++ b/apim/3.x/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 3.1.64
+- [X] Add support of rate limit timeout
+
 ### 3.1.63
 - [X] Add support of user password policy config on API Management
 

--- a/apim/3.x/Chart.yaml
+++ b/apim/3.x/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: apim3
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 3.1.63
+version: 3.1.64
 appVersion: 3.20.1
 description: Official Gravitee.io Helm chart for API Management 3.x
 home: https://gravitee.io
@@ -20,4 +20,4 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/apim3?modal=changelog
   artifacthub.io/changes: |
-    - Add support of user password policy config on API Management
+    - Add support of rate limit timeout

--- a/apim/3.x/templates/gateway/gateway-configmap.yaml
+++ b/apim/3.x/templates/gateway/gateway-configmap.yaml
@@ -341,6 +341,10 @@ data:
         {{- end }}
       {{- end }}
 
+      {{- if .Values.gateway.services.ratelimit }}
+      ratelimit: {{ toYaml .Values.gateway.services.ratelimit | nindent 8 }}
+      {{- end }}
+
     {{- if or .Values.gateway.handlers }}
     handlers:
 {{ toYaml .Values.gateway.handlers | indent 6 }}

--- a/apim/3.x/tests/gateway/configmap_test.yaml
+++ b/apim/3.x/tests/gateway/configmap_test.yaml
@@ -1,0 +1,16 @@
+suite: Test Management API default configmap
+templates:
+  - "gateway/gateway-configmap.yaml"
+tests:
+  - it: Set rate limit timeout
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        services:
+          ratelimit:
+            timeout: 10000
+    asserts:
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: " * ratelimit: \n 
+                     *   timeout: 10000\n"


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-990

**Description**

Linked to:
https://github.com/gravitee-io/gravitee-policy-ratelimit/pull/78

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
