### PR TITLE
logback.xml

### DIFF
--- a/am/CHANGELOG.md
+++ b/am/CHANGELOG.md
@@ -5,6 +5,7 @@ This file documents all notable changes to [Gravitee.io Access Management 3.x](h
 ### 1.0.57
 
 - [X] Add hook-delete-policy
+- [X] Allow users to use `logging.debug: true` when they define their own configuration file by defining a volume
 - [X] Remove ingress nginx annotation when `ingress.class` is not nginx
 
 ### 1.0.56

--- a/am/Chart.yaml
+++ b/am/Chart.yaml
@@ -25,3 +25,4 @@ annotations:
   artifacthub.io/changes: |
     - Add hook-delete-policy
     - Remove ingress nginx annotation when `ingress.class` is not nginx
+    - Allow users to use `logging.debug: true` when they define their own configuration file by defining a volume

--- a/am/templates/_helpers.tpl
+++ b/am/templates/_helpers.tpl
@@ -243,6 +243,19 @@ Usage:
 {{- end }}
 
 {{/*
+Returns logback if an extraVolumes named config is defined and gateway.logging.debug is set to true, else return config
+Usage:
+{{ include "gateway.logbackVolumeName" . }}
+*/}}
+{{- define "gateway.logbackVolumeName" -}}
+{{- if and (include "gateway.externalConfig" .) (.Values.gateway.logging.debug) }}
+{{- print "logback" -}}
+{{- else -}}
+{{- print "config" -}}
+{{- end }}
+{{- end }}
+
+{{/*
 Returns true if an extraVolumes named config is defined
 Usage:
 {{ include "api.externalConfig" . }}
@@ -252,6 +265,19 @@ Usage:
 {{- if contains "- name: config" .Values.api.extraVolumes  }}
 {{- print "true" -}}
 {{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns logback if an extraVolumes named config is defined and api.logging.debug is set to true, else return config
+Usage:
+{{ include "api.logbackVolumeName" . }}
+*/}}
+{{- define "api.logbackVolumeName" -}}
+{{- if and (include "api.externalConfig" .) (.Values.api.logging.debug) }}
+{{- print "logback" -}}
+{{- else -}}
+{{- print "config" -}}
 {{- end }}
 {{- end }}
 

--- a/am/templates/api/api-configmap.yaml
+++ b/am/templates/api/api-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.api.enabled) (not (include "api.externalConfig" .)) -}}
+{{- if and (.Values.api.enabled) (or (not (include "api.externalConfig" .)) (.Values.api.logging.debug)) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 data:
+  {{- if not (include "api.externalConfig" .)}}
   gravitee.yml: |
     jetty:
       host: {{ .Values.api.http.host | default "0.0.0.0" }}
@@ -431,8 +432,7 @@ data:
       alert-engine-connector-ws:
         enabled: false
     {{- end }}
-
-
+  {{- end }}
   {{- if .Values.api.logging.debug }}
   logback.xml: |
     <?xml version="1.0" encoding="UTF-8"?>

--- a/am/templates/api/api-deployment.yaml
+++ b/am/templates/api/api-deployment.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.api.enabled -}}
 {{- $initContainers := .Values.initContainers -}}
 {{- $serviceAccount := include "am.serviceAccount" . -}}
+{{- $logbackVolumeName := include "api.logbackVolumeName" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -163,7 +164,7 @@ spec:
               mountPath: /opt/graviteeio-am-management-api/config/gravitee.yml
               subPath: gravitee.yml
           {{- if .Values.api.logging.debug }}
-            - name: config
+            - name: {{ $logbackVolumeName }}
               mountPath: /opt/graviteeio-am-management-api/config/logback.xml
               subPath: logback.xml
           {{- end }}
@@ -196,6 +197,11 @@ spec:
       volumes:
         {{- if not (include "api.externalConfig" .) }}
         - name: config
+          configMap:
+            name: {{ template "gravitee.api.fullname" . }}
+        {{- end }}
+        {{- if and (include "api.externalConfig" .) (.Values.api.logging.debug) }}
+        - name: logback
           configMap:
             name: {{ template "gravitee.api.fullname" . }}
         {{- end }}

--- a/am/templates/gateway/gateway-configmap.yaml
+++ b/am/templates/gateway/gateway-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.gateway.enabled) (not (include "gateway.externalConfig" .)) -}}
+{{- if and (.Values.gateway.enabled) (or (not (include "gateway.externalConfig" .)) (.Values.gateway.logging.debug)) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 data:
+  {{- if not (include "gateway.externalConfig" .)}}
   gravitee.yml: |
     # Gateway HTTP server
     http:
@@ -398,7 +399,7 @@ data:
       alert-engine-connector-ws:
         enabled: false
     {{- end }}
-
+  {{- end }}
   {{- if .Values.gateway.logging.debug }}
   logback.xml: |
     <?xml version="1.0" encoding="UTF-8"?>

--- a/am/templates/gateway/gateway-deployment.yaml
+++ b/am/templates/gateway/gateway-deployment.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.gateway.enabled -}}
 {{- $initContainers := .Values.initContainers -}}
 {{- $serviceAccount := include "am.serviceAccount" . -}}
+{{- $logbackVolumeName := include "gateway.logbackVolumeName" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -161,7 +162,7 @@ spec:
               mountPath: /opt/graviteeio-am-gateway/config/gravitee.yml
               subPath: gravitee.yml
           {{- if .Values.gateway.logging.debug }}
-            - name: config
+            - name: {{ $logbackVolumeName }}
               mountPath: /opt/graviteeio-am-gateway/config/logback.xml
               subPath: logback.xml
           {{- end }}
@@ -189,6 +190,11 @@ spec:
       volumes:
         {{- if not (include "gateway.externalConfig" .) }}
         - name: config
+          configMap:
+            name: {{ template "gravitee.gateway.fullname" . }}
+        {{- end }}
+        {{- if and (include "gateway.externalConfig" .) (.Values.gateway.logging.debug) }}
+        - name: logback
           configMap:
             name: {{ template "gravitee.gateway.fullname" . }}
         {{- end }}

--- a/am/tests/api/external_configuration.yaml
+++ b/am/tests/api/external_configuration.yaml
@@ -21,6 +21,42 @@ tests:
     asserts:
       - hasDocuments:
           count: 1
+      - isNull:
+          path: data.logback\.xml
+      - isNotNull:
+          path: data.gravitee\.yml
+
+  - it: Should generate api-configmap.yaml  when logging.debug is true
+    template: api/api-configmap.yaml
+    set:
+      api:
+        logging:
+          debug: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isNotNull:
+          path: data.logback\.xml
+      - isNotNull:
+          path: data.gravitee\.yml
+
+  - it: Should generate api-configmap.yaml when logging.debug is true and extraVolumes 'config' is defined
+    template: api/api-configmap.yaml
+    set:
+      api:
+        logging:
+          debug: true
+        extraVolumes: |
+          - name: config
+            secret:
+              secretName: gravitee-yml-secret-name
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isNotNull:
+          path: data.logback\.xml
+      - isNull:
+          path: data.gravitee\.yml
 
   - it: Should generate a volume named config in api-deployment.yaml
     template: api/api-deployment.yaml
@@ -64,3 +100,29 @@ tests:
             name: config
             secret:
               secretName: gravitee-yml-secret-name
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: logback
+            secret:
+              secretName: gravitee-yml-secret-name
+
+  - it: Should generate a volume and a volumeMount named logback in api-deployment.yaml
+    template: api/api-deployment.yaml
+    set:
+      api:
+        logging:
+          debug: true
+        extraVolumes: |
+          - name: config
+            secret:
+              secretName: gravitee-yml-secret-name
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].name
+          value: logback
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: logback

--- a/am/tests/gateway/external_configuration.yaml
+++ b/am/tests/gateway/external_configuration.yaml
@@ -21,6 +21,42 @@ tests:
     asserts:
       - hasDocuments:
           count: 1
+      - isNull:
+          path: data.logback\.xml
+      - isNotNull:
+          path: data.gravitee\.yml
+
+  - it: Should generate gateway-configmap.yaml  when logging.debug is true
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        logging:
+          debug: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isNotNull:
+          path: data.logback\.xml
+      - isNotNull:
+          path: data.gravitee\.yml
+
+  - it: Should generate gateway-configmap.yaml when logging.debug is true and extraVolumes 'config' is defined
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        logging:
+          debug: true
+        extraVolumes: |
+          - name: config
+            secret:
+              secretName: gravitee-yml-secret-name
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isNotNull:
+          path: data.logback\.xml
+      - isNull:
+          path: data.gravitee\.yml
 
   - it: Should generate a volume named config in gateway-deployment.yaml
     template: gateway/gateway-deployment.yaml
@@ -64,3 +100,29 @@ tests:
             name: config
             secret:
               secretName: gravitee-yml-secret-name
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: logback
+            secret:
+              secretName: gravitee-yml-secret-name
+
+  - it: Should generate a volume and a volumeMount named logback in gateway-deployment.yaml
+    template: gateway/gateway-deployment.yaml
+    set:
+      gateway:
+        logging:
+          debug: true
+        extraVolumes: |
+          - name: config
+            secret:
+              secretName: gravitee-yml-secret-name
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].name
+          value: logback
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: logback

--- a/apim/3.x/CHANGELOG.md
+++ b/apim/3.x/CHANGELOG.md
@@ -6,6 +6,7 @@ This file documents all notable changes to [Gravitee.io API Management 3.x](http
 ### 3.1.65
 
 - [X] Add hook-delete-policy
+- [X] Allow users to use `logging.debug: true` when they define their own configuration file by defining a volume
 - [X] Add check to allow automatic Redis plugin download only for versions prior to 3.21.0 (it is now embedded in the distribution)
 - [X] Add SSL and Sentinel configuration management for Redis and updated doc. 
 - [X] Auto-generate `PORTAL_BASE_HREF` and `CONSOLE_BASE_HREF` environment variables

--- a/apim/3.x/Chart.yaml
+++ b/apim/3.x/Chart.yaml
@@ -25,3 +25,4 @@ annotations:
     - Add SSL and Sentinel configuration management for Redis and updated doc.
     - Auto-generate `PORTAL_BASE_HREF` and `CONSOLE_BASE_HREF` environment variables
     - Remove ingress nginx annotation when `ingress.class` is not nginx
+    - Allow users to use `logging.debug: true` when they define their own configuration file by defining a volume

--- a/apim/3.x/templates/_helpers.tpl
+++ b/apim/3.x/templates/_helpers.tpl
@@ -266,6 +266,19 @@ Usage:
 {{- end }}
 
 {{/*
+Returns logback if an extraVolumes named config is defined and gateway.logging.debug is set to true, else return config
+Usage:
+{{ include "gateway.logbackVolumeName" . }}
+*/}}
+{{- define "gateway.logbackVolumeName" -}}
+{{- if and (include "gateway.externalConfig" .) (.Values.gateway.logging.debug) }}
+{{- print "logback" -}}
+{{- else -}}
+{{- print "config" -}}
+{{- end }}
+{{- end }}
+
+{{/*
 Returns true if an extraVolumes named config is defined
 Usage:
 {{ include "api.externalConfig" . }}
@@ -275,6 +288,19 @@ Usage:
 {{- if contains "- name: config" .Values.api.extraVolumes  }}
 {{- print "true" -}}
 {{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns logback if an extraVolumes named config is defined and api.logging.debug is set to true, else return config
+Usage:
+{{ include "api.logbackVolumeName" . }}
+*/}}
+{{- define "api.logbackVolumeName" -}}
+{{- if and (include "api.externalConfig" .) (.Values.api.logging.debug) }}
+{{- print "logback" -}}
+{{- else -}}
+{{- print "config" -}}
 {{- end }}
 {{- end }}
 

--- a/apim/3.x/templates/api/api-configmap.yaml
+++ b/apim/3.x/templates/api/api-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.api.enabled) (not (include "api.externalConfig" .)) -}}
+{{- if and (.Values.api.enabled) (or (not (include "api.externalConfig" .)) (.Values.api.logging.debug)) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 data:
+{{- if not (include "api.externalConfig" .)}}
   gravitee.yml: |
     {{- if .Values.api.ssl.enabled }}
     jetty:
@@ -481,6 +482,7 @@ data:
     {{- if .Values.api.api }}
       api: {{- toYaml .Values.api.api | nindent 6 -}}
     {{- end}}
+    {{- end }}
   {{- if .Values.api.logging.debug }}
   logback.xml: |
     <?xml version="1.0" encoding="UTF-8"?>

--- a/apim/3.x/templates/api/api-deployment.yaml
+++ b/apim/3.x/templates/api/api-deployment.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.api.enabled -}}
 {{- $initContainers := .Values.initContainers -}}
 {{- $serviceAccount := include "apim.serviceAccount" . -}}
+{{- $logbackVolumeName := include "api.logbackVolumeName" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -180,7 +181,7 @@ spec:
               mountPath: /opt/graviteeio-management-api/config/gravitee.yml
               subPath: gravitee.yml
           {{- if .Values.api.logging.debug }}
-            - name: config
+            - name: {{ $logbackVolumeName }}
               mountPath: /opt/graviteeio-management-api/config/logback.xml
               subPath: logback.xml
           {{- end }}
@@ -216,6 +217,11 @@ spec:
       volumes:
         {{- if not (include "api.externalConfig" .) }}
         - name: config
+          configMap:
+            name: {{ template "gravitee.api.fullname" . }}
+        {{- end }}
+        {{- if and (include "api.externalConfig" .) (.Values.api.logging.debug) }}
+        - name: logback
           configMap:
             name: {{ template "gravitee.api.fullname" . }}
         {{- end }}

--- a/apim/3.x/templates/gateway/gateway-configmap.yaml
+++ b/apim/3.x/templates/gateway/gateway-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.gateway.enabled) (not (include "gateway.externalConfig" .)) -}}
+{{- if and (.Values.gateway.enabled) (or (not (include "gateway.externalConfig" .)) (.Values.gateway.logging.debug)) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 data:
+  {{- if not (include "gateway.externalConfig" .)}}
   gravitee.yml: |
     # Gateway HTTP server
     http:
@@ -413,6 +414,7 @@ data:
       legacy:
         enabled: {{ .Values.gateway.classloader.legacy.enabled }}
 
+  {{- end }}
   {{- if .Values.gateway.logging.debug }}
   logback.xml: |
     <?xml version="1.0" encoding="UTF-8"?>

--- a/apim/3.x/templates/gateway/gateway-deployment.yaml
+++ b/apim/3.x/templates/gateway/gateway-deployment.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.gateway.enabled -}}
 {{- $initContainers := .Values.initContainers -}}
 {{- $serviceAccount := include "apim.serviceAccount" . -}}
+{{- $logbackVolumeName := include "gateway.logbackVolumeName" . -}}
 apiVersion: apps/v1
 kind: {{ .Values.gateway.type }}
 metadata:
@@ -185,7 +186,7 @@ spec:
               mountPath: /opt/graviteeio-gateway/config/gravitee.yml
               subPath: gravitee.yml
           {{- if .Values.gateway.logging.debug }}
-            - name: config
+            - name: {{ $logbackVolumeName }}
               mountPath: /opt/graviteeio-gateway/config/logback.xml
               subPath: logback.xml
           {{- end }}
@@ -216,6 +217,11 @@ spec:
       volumes:
         {{- if not (include "gateway.externalConfig" .) }}
         - name: config
+          configMap:
+            name: {{ template "gravitee.gateway.fullname" . }}
+        {{- end }}
+        {{- if and (include "gateway.externalConfig" .) (.Values.gateway.logging.debug) }}
+        - name: logback
           configMap:
             name: {{ template "gravitee.gateway.fullname" . }}
         {{- end }}

--- a/apim/3.x/tests/api/external_configuration.yaml
+++ b/apim/3.x/tests/api/external_configuration.yaml
@@ -21,6 +21,42 @@ tests:
     asserts:
       - hasDocuments:
           count: 1
+      - isNull:
+          path: data.logback\.xml
+      - isNotNull:
+          path: data.gravitee\.yml
+
+  - it: Should generate api-configmap.yaml  when logging.debug is true
+    template: api/api-configmap.yaml
+    set:
+      api:
+        logging:
+          debug: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isNotNull:
+          path: data.logback\.xml
+      - isNotNull:
+          path: data.gravitee\.yml
+
+  - it: Should generate api-configmap.yaml when logging.debug is true and extraVolumes 'config' is defined
+    template: api/api-configmap.yaml
+    set:
+      api:
+        logging:
+          debug: true
+        extraVolumes: |
+          - name: config
+            secret:
+              secretName: gravitee-yml-secret-name
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isNotNull:
+          path: data.logback\.xml
+      - isNull:
+          path: data.gravitee\.yml
 
   - it: Should generate a volume named config in api-deployment.yaml
     template: api/api-deployment.yaml
@@ -64,3 +100,29 @@ tests:
             name: config
             secret:
               secretName: gravitee-yml-secret-name
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: logback
+            secret:
+              secretName: gravitee-yml-secret-name
+
+  - it: Should generate a volume and a volumeMount named logback in api-deployment.yaml
+    template: api/api-deployment.yaml
+    set:
+      api:
+        logging:
+          debug: true
+        extraVolumes: |
+          - name: config
+            secret:
+              secretName: gravitee-yml-secret-name
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].name
+          value: logback
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: logback

--- a/apim/3.x/tests/gateway/external_configuration.yaml
+++ b/apim/3.x/tests/gateway/external_configuration.yaml
@@ -21,6 +21,42 @@ tests:
     asserts:
       - hasDocuments:
           count: 1
+      - isNull:
+          path: data.logback\.xml
+      - isNotNull:
+          path: data.gravitee\.yml
+
+  - it: Should generate gateway-configmap.yaml  when logging.debug is true
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        logging:
+          debug: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isNotNull:
+          path: data.logback\.xml
+      - isNotNull:
+          path: data.gravitee\.yml
+
+  - it: Should generate gateway-configmap.yaml when logging.debug is true and extraVolumes 'config' is defined
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        logging:
+          debug: true
+        extraVolumes: |
+          - name: config
+            secret:
+              secretName: gravitee-yml-secret-name
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isNotNull:
+          path: data.logback\.xml
+      - isNull:
+          path: data.gravitee\.yml
 
   - it: Should generate a volume named config in gateway-deployment.yaml
     template: gateway/gateway-deployment.yaml
@@ -64,3 +100,29 @@ tests:
             name: config
             secret:
               secretName: gravitee-yml-secret-name
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: logback
+            secret:
+              secretName: gravitee-yml-secret-name
+
+  - it: Should generate a volume and a volumeMount named logback in gateway-deployment.yaml
+    template: gateway/gateway-deployment.yaml
+    set:
+      gateway:
+        logging:
+          debug: true
+        extraVolumes: |
+          - name: config
+            secret:
+              secretName: gravitee-yml-secret-name
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].name
+          value: logback
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: logback

--- a/apim/3.x/values.yaml
+++ b/apim/3.x/values.yaml
@@ -1022,6 +1022,7 @@ gateway:
   # If you want to use your own gravitee.yml you have to provide your configmap or secret in extraVolume part.
   # the name of the volume MUST be "config".
   # In this case, values configuration related to gravitee.yaml defined in this file will be ignored
+  # If you also define your own logback.xml in the "config" volume, you have to set logging.debug: false or your file will be ignored
   #extraVolumes: |
   #  - name: config
   #    configMap:


### PR DESCRIPTION
**Issue**

Unable to use the value parameter `logging.debug: true` when using an external gravitee.yml

**Description**

This pr allow user to set `logging.debug: true` when using an external gravitee.yml:
- a configMag is generated with logback.xml
- The provided gravitee.yml is used by the application
