### PR TITLE
feat(apim): Add check to allow automatic Redis plugin download only f…

### DIFF
--- a/apim/3.x/CHANGELOG.md
+++ b/apim/3.x/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 3.1.65
+
+- [X] Add check to allow automatic Redis plugin download only for versions prior to 3.21.0 (it is now embedded in the distribution)
+
 ### 3.1.64
 
 - [X] Add `gracefulShutdown` in gateway configuration

--- a/apim/3.x/Chart.yaml
+++ b/apim/3.x/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: apim3
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 3.1.64
+version: 3.1.65
 appVersion: 3.20.1
 description: Official Gravitee.io Helm chart for API Management 3.x
 home: https://gravitee.io

--- a/apim/3.x/templates/_helpers.tpl
+++ b/apim/3.x/templates/_helpers.tpl
@@ -107,11 +107,9 @@ Create initContainers for downloading plugins ext plugin-ext
 {{- end -}}
 
 {{- define "redis.plugin" -}}
-{{- if .Values.redis.download -}}
-  {{- $version := (.Values.redis.repositoryVersion | default .Values.gateway.image.tag | default .Chart.AppVersion ) -}}
-  {{- if or (eq "nightly" $version) (contains "latest" $version) -}}
-    {{- printf "https://download.gravitee.io/graviteeio-apim/plugins/repositories/gravitee-apim-repository-redis/gravitee-apim-repository-redis-%s.zip" (.Values.redis.repositoryVersion | default .Chart.AppVersion) -}}
-  {{- else if $version | semverCompare "<=3.5.18" -}}
+{{- $version := (.Values.redis.repositoryVersion | default .Values.gateway.image.tag | default .Chart.AppVersion ) -}}
+{{- if and .Values.redis.download (not (contains "latest" $version)) (ne "nightly" $version) ($version | semverCompare "<3.21.0") -}}
+  {{- if $version | semverCompare "<=3.5.18" -}}
     {{- printf "https://download.gravitee.io/graviteeio-apim/plugins/repositories/gravitee-repository-redis/gravitee-repository-redis-%s.zip" $version -}}
   {{- else -}}
     {{- printf "https://download.gravitee.io/graviteeio-apim/plugins/repositories/gravitee-apim-repository-redis/gravitee-apim-repository-redis-%s.zip" $version -}}

--- a/apim/3.x/tests/gateway/deployment_redis_test.yaml
+++ b/apim/3.x/tests/gateway/deployment_redis_test.yaml
@@ -87,9 +87,126 @@ tests:
             - name: graviteeio-apim-plugins
               mountPath: /tmp/plugins
 
-
-  - it: Check redis plugin with nightly version
+  - it: Check redis plugin with old version of image (should be 3.15.2)
     template: gateway/gateway-deployment.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 3.15.2
+    set:
+        ratelimit:
+          type: "redis"
+        gateway:
+          ratelimit:
+            redis:
+              host: localhost
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].name
+          value: graviteeio-apim-plugins
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].mountPath
+          value: /opt/graviteeio-gateway/plugins-ext
+      - equal:
+          path: spec.template.spec.volumes[1].name
+          value: graviteeio-apim-plugins
+      - equal:
+          path: spec.template.spec.volumes[1].emptyDir
+          value: {}
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: get-plugins
+            image: "alpine:latest"
+            imagePullPolicy: Always
+            command: ['sh', '-c', "mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-apim-repository-redis-3.15.2.zip  2>/dev/null || true ) && wget https://download.gravitee.io/graviteeio-apim/plugins/repositories/gravitee-apim-repository-redis/gravitee-apim-repository-redis-3.15.2.zip"]
+            env: []
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1001
+            volumeMounts:
+              - name: graviteeio-apim-plugins
+                mountPath: /tmp/plugins
+
+  - it: Check redis plugin not downloaded when version is 3.21.0 or superior
+    template: gateway/gateway-deployment.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 3.21.0
+    release:
+      name: my-apim
+      namespace: unittest
+    set:
+      ratelimit:
+        type: "redis"
+      gateway:
+        ratelimit:
+          redis:
+            host: localhost
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec
+          value:
+            serviceAccountName: my-apim-apim3
+            affinity:
+              { }
+            nodeSelector:
+              { }
+            topologySpreadConstraints:
+              [ ]
+            tolerations:
+              [ ]
+            terminationGracePeriodSeconds: 30
+            initContainers:
+            containers:
+              - name: my-apim-apim3-gateway
+                image: "graviteeio/apim-gateway:3.21.0"
+                imagePullPolicy: Always
+                securityContext:
+                  runAsNonRoot: true
+                  runAsUser: 1001
+                ports:
+                  - name: http
+                    containerPort: 8082
+                env:
+                envFrom:
+                  [ ]
+                livenessProbe:
+                  failureThreshold: 3
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  tcpSocket:
+                    port: http
+                readinessProbe:
+                  failureThreshold: 3
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  tcpSocket:
+                    port: http
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 512Mi
+                  requests:
+                    cpu: 200m
+                    memory: 256Mi
+                volumeMounts:
+                  - name: config
+                    mountPath: /opt/graviteeio-gateway/config/gravitee.yml
+                    subPath: gravitee.yml
+            volumes:
+              - name: config
+                configMap:
+                  name: my-apim-apim3-gateway
+
+  - it: Check redis plugin not downloaded with nightly version
+    template: gateway/gateway-deployment.yaml
+    chart:
+      version: 1.0.0-chart
+      appVersion: 3.21.0
     set:
       ratelimit:
         type: "redis"
@@ -115,65 +232,96 @@ tests:
           value: graviteeio-apim-plugins
       - equal:
           path: spec.template.spec.volumes[1].emptyDir
-          value: {}
+          value: { }
       - contains:
           path: spec.template.spec.initContainers
           content:
             name: get-plugins
             image: "alpine:latest"
             imagePullPolicy: Always
-            command: ['sh', '-c', "mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-apim-repository-redis-3.11.0.zip  2>/dev/null || true ) && wget https://download.gravitee.io/graviteeio-apim/plugins/repositories/gravitee-apim-repository-redis/gravitee-apim-repository-redis-3.11.0.zip"]
-            env: []
+            command: [ 'sh', '-c', "mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-apim-repository-redis-3.11.0.zip  2>/dev/null || true ) && wget https://download.gravitee.io/graviteeio-apim/plugins/repositories/gravitee-apim-repository-redis/gravitee-apim-repository-redis-3.11.0.zip" ]
+            env: [ ]
             securityContext:
               runAsNonRoot: true
               runAsUser: 1001
             volumeMounts:
-            - name: graviteeio-apim-plugins
-              mountPath: /tmp/plugins
+              - name: graviteeio-apim-plugins
+                mountPath: /tmp/plugins
 
-  - it: Check redis plugin with latest version of image (should be 3.15.2)
+  - it: Check redis plugin not downloaded when version is superior to 3.21.0 and latest
     template: gateway/gateway-deployment.yaml
     chart:
       version: 1.0.0-chart
-      appVersion: 3.15.2
+      appVersion: 3.21.x-latest
+    release:
+      name: my-apim
+      namespace: unittest
     set:
+      ratelimit:
+        type: "redis"
+      gateway:
+        image:
+          tag: master-latest
         ratelimit:
-            type: "redis"
-        gateway:
-            image:
-                tag: master-latest
-            ratelimit:
-                redis:
-                    host: localhost
+          redis:
+            host: localhost
     asserts:
-        - hasDocuments:
-              count: 1
-        - equal:
-              path: spec.template.spec.containers[0].volumeMounts[1].name
-              value: graviteeio-apim-plugins
-        - equal:
-              path: spec.template.spec.containers[0].volumeMounts[1].mountPath
-              value: /opt/graviteeio-gateway/plugins-ext
-        - equal:
-              path: spec.template.spec.volumes[1].name
-              value: graviteeio-apim-plugins
-        - equal:
-              path: spec.template.spec.volumes[1].emptyDir
-              value: {}
-        - contains:
-              path: spec.template.spec.initContainers
-              content:
-                  name: get-plugins
-                  image: "alpine:latest"
-                  imagePullPolicy: Always
-                  command: ['sh', '-c', "mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-apim-repository-redis-3.15.2.zip  2>/dev/null || true ) && wget https://download.gravitee.io/graviteeio-apim/plugins/repositories/gravitee-apim-repository-redis/gravitee-apim-repository-redis-3.15.2.zip"]
-                  env: []
-                  securityContext:
-                      runAsNonRoot: true
-                      runAsUser: 1001
-                  volumeMounts:
-                      - name: graviteeio-apim-plugins
-                        mountPath: /tmp/plugins
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec
+          value:
+            serviceAccountName: my-apim-apim3
+            affinity:
+              { }
+            nodeSelector:
+              { }
+            topologySpreadConstraints:
+              [ ]
+            tolerations:
+              [ ]
+            terminationGracePeriodSeconds: 30
+            initContainers:
+            containers:
+              - name: my-apim-apim3-gateway
+                image: "graviteeio/apim-gateway:master-latest"
+                imagePullPolicy: Always
+                securityContext:
+                  runAsNonRoot: true
+                  runAsUser: 1001
+                ports:
+                  - name: http
+                    containerPort: 8082
+                env:
+                envFrom:
+                  [ ]
+                livenessProbe:
+                  failureThreshold: 3
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  tcpSocket:
+                    port: http
+                readinessProbe:
+                  failureThreshold: 3
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  tcpSocket:
+                    port: http
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 512Mi
+                  requests:
+                    cpu: 200m
+                    memory: 256Mi
+                volumeMounts:
+                  - name: config
+                    mountPath: /opt/graviteeio-gateway/config/gravitee.yml
+                    subPath: gravitee.yml
+            volumes:
+              - name: config
+                configMap:
+                  name: my-apim-apim3-gateway
 
   - it: Check redis plugin to not download
     template: gateway/gateway-deployment.yaml


### PR DESCRIPTION
…or versions prior to 3.21.0 (it is now embedded in the distribution)

**Issue**

https://gravitee.atlassian.net/browse/ARCHI-109

**Description**

After migrating the Spring Data Redis client used in APIM to the Vert.x one (for performance purpose), there is no need to manage the download of the Redis client since it is now embedded in the distribution (thanks to the size of the dependency that is now very small). This PR adds a check on the version and only allow to download the Redis plugin if APIM version is lower to 3.21.0.
