### PR TITLE
Adding option to allow for http communication to management api

### DIFF
--- a/apim/3.x/README.adoc
+++ b/apim/3.x/README.adoc
@@ -339,6 +339,10 @@ Please be aware that the Elasticsearch installed by Gravitee is NOT recommended 
 `+null+`, defaults to Management API ingress value)_
 |`+[apim.example.com]/management+`
 
+|`+ui.scheme+` |Whether to use HTTP or HTTPS to communicate with Management API,
+defaults to https
+|`https`
+
 |`+ui.title+` |UI Portal title _(if set to `+null+`, retrieved from the
 management repository)_ |`+API Portal+`
 

--- a/apim/3.x/README.adoc
+++ b/apim/3.x/README.adoc
@@ -339,10 +339,6 @@ Please be aware that the Elasticsearch installed by Gravitee is NOT recommended 
 `+null+`, defaults to Management API ingress value)_
 |`+[apim.example.com]/management+`
 
-|`+ui.scheme+` |Whether to use HTTP or HTTPS to communicate with Management API,
-defaults to https
-|`https`
-
 |`+ui.title+` |UI Portal title _(if set to `+null+`, retrieved from the
 management repository)_ |`+API Portal+`
 
@@ -693,6 +689,10 @@ TLS termination] |`+[apim.example.com]+`
 
 |`+api.ingress.tls.secretName+` |Ingress TLS K8s secret name containing
 the TLS private key and certificate |`+api-custom-cert+`
+
+|`+api.ingress.management.scheme+` |Whether to use HTTP or HTTPS to communicate with Management API,
+defaults to https
+|`https`
 
 |`+api.resources.limits.cpu+` |K8s pod deployment
 https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource/[limits

--- a/apim/3.x/templates/portal/portal-configmap.yaml
+++ b/apim/3.x/templates/portal/portal-configmap.yaml
@@ -20,9 +20,9 @@ data:
       "baseURL": "{{ .Values.portal.baseURL }}",
       {{- else }}
       {{- if hasSuffix "/" .Values.api.ingress.portal.path }}
-      "baseURL": "{{ .Values.portal.scheme }}://{{ index .Values.api.ingress.portal.hosts 0 }}{{ .Values.api.ingress.portal.path }}environments/DEFAULT",
+      "baseURL": "{{ .Values.api.ingress.portal.scheme }}://{{ index .Values.api.ingress.portal.hosts 0 }}{{ .Values.api.ingress.portal.path }}environments/DEFAULT",
       {{- else }}
-      "baseURL": "{{ .Values.portal.scheme }}://{{ index .Values.api.ingress.portal.hosts 0 }}{{ .Values.api.ingress.portal.path }}/environments/DEFAULT",
+      "baseURL": "{{ .Values.api.ingress.portal.scheme }}://{{ index .Values.api.ingress.portal.hosts 0 }}{{ .Values.api.ingress.portal.path }}/environments/DEFAULT",
       {{- end }}
       {{- end }}
       "loaderURL": "assets/images/gravitee-loader.gif",

--- a/apim/3.x/templates/portal/portal-configmap.yaml
+++ b/apim/3.x/templates/portal/portal-configmap.yaml
@@ -20,9 +20,9 @@ data:
       "baseURL": "{{ .Values.portal.baseURL }}",
       {{- else }}
       {{- if hasSuffix "/" .Values.api.ingress.portal.path }}
-      "baseURL": "https://{{ index .Values.api.ingress.portal.hosts 0 }}{{ .Values.api.ingress.portal.path }}environments/DEFAULT",
+      "baseURL": "{{ .Values.portal.scheme }}://{{ index .Values.api.ingress.portal.hosts 0 }}{{ .Values.api.ingress.portal.path }}environments/DEFAULT",
       {{- else }}
-      "baseURL": "https://{{ index .Values.api.ingress.portal.hosts 0 }}{{ .Values.api.ingress.portal.path }}/environments/DEFAULT",
+      "baseURL": "{{ .Values.portal.scheme }}://{{ index .Values.api.ingress.portal.hosts 0 }}{{ .Values.api.ingress.portal.path }}/environments/DEFAULT",
       {{- end }}
       {{- end }}
       "loaderURL": "assets/images/gravitee-loader.gif",

--- a/apim/3.x/templates/ui/ui-configmap.yaml
+++ b/apim/3.x/templates/ui/ui-configmap.yaml
@@ -20,9 +20,9 @@ data:
       "baseURL": "{{ .Values.ui.baseURL }}"
       {{- else }}
       {{- if hasSuffix "/" .Values.api.ingress.management.path }}
-      "baseURL": "https://{{ index .Values.api.ingress.management.hosts 0 }}{{ .Values.api.ingress.management.path }}organizations/DEFAULT/environments/DEFAULT/"
+      "baseURL": "{{.Values.ui.scheme }}://{{ index .Values.api.ingress.management.hosts 0 }}{{ .Values.api.ingress.management.path }}organizations/DEFAULT/environments/DEFAULT/"
       {{- else }}
-      "baseURL": "https://{{ index .Values.api.ingress.management.hosts 0 }}{{ .Values.api.ingress.management.path }}/organizations/DEFAULT/environments/DEFAULT/"
+      "baseURL": "{{.Values.ui.scheme }}://{{ index .Values.api.ingress.management.hosts 0 }}{{ .Values.api.ingress.management.path }}/organizations/DEFAULT/environments/DEFAULT/"
       {{- end }}
       {{- end }}
       {{- if .Values.ui.managementTitle }},

--- a/apim/3.x/templates/ui/ui-configmap.yaml
+++ b/apim/3.x/templates/ui/ui-configmap.yaml
@@ -20,9 +20,9 @@ data:
       "baseURL": "{{ .Values.ui.baseURL }}"
       {{- else }}
       {{- if hasSuffix "/" .Values.api.ingress.management.path }}
-      "baseURL": "{{.Values.ui.scheme }}://{{ index .Values.api.ingress.management.hosts 0 }}{{ .Values.api.ingress.management.path }}organizations/DEFAULT/environments/DEFAULT/"
+      "baseURL": "{{ .Values.api.ingress.management.scheme }}://{{ index .Values.api.ingress.management.hosts 0 }}{{ .Values.api.ingress.management.path }}organizations/DEFAULT/environments/DEFAULT/"
       {{- else }}
-      "baseURL": "{{.Values.ui.scheme }}://{{ index .Values.api.ingress.management.hosts 0 }}{{ .Values.api.ingress.management.path }}/organizations/DEFAULT/environments/DEFAULT/"
+      "baseURL": "{{ .Values.api.ingress.management.scheme }}://{{ index .Values.api.ingress.management.hosts 0 }}{{ .Values.api.ingress.management.path }}/organizations/DEFAULT/environments/DEFAULT/"
       {{- end }}
       {{- end }}
       {{- if .Values.ui.managementTitle }},

--- a/apim/3.x/values.yaml
+++ b/apim/3.x/values.yaml
@@ -1025,6 +1025,7 @@ gateway:
 portal:
   enabled: true
   name: portal
+  scheme: https # should be https or http
   replicaCount: 1
   image:
     repository: graviteeio/apim-portal-ui
@@ -1170,6 +1171,7 @@ ui:
   enabled: true
   name: ui
   companyName: Gravitee.io
+  scheme: https # https or http
   title: Management UI
   managementTitle: API Management
   documentationLink: http://docs.gravitee.io/

--- a/apim/3.x/values.yaml
+++ b/apim/3.x/values.yaml
@@ -603,6 +603,7 @@ api:
   ingress:
     management:
       enabled: true
+      scheme: https # should be https or http
       pathType: Prefix
       path: /management
       ingressClassName: ""
@@ -620,6 +621,7 @@ api:
       #    secretName: api-custom-cert
     portal:
       enabled: true
+      scheme: https # should be https or http
       pathType: Prefix
       path: /portal
       ingressClassName: ""

--- a/apim/3.x/values.yaml
+++ b/apim/3.x/values.yaml
@@ -1027,7 +1027,6 @@ gateway:
 portal:
   enabled: true
   name: portal
-  scheme: https # should be https or http
   replicaCount: 1
   image:
     repository: graviteeio/apim-portal-ui
@@ -1173,7 +1172,6 @@ ui:
   enabled: true
   name: ui
   companyName: Gravitee.io
-  scheme: https # https or http
   title: Management UI
   managementTitle: API Management
   documentationLink: http://docs.gravitee.io/


### PR DESCRIPTION
I saw that HTTP had been requested for testing purposes here:  https://community.gravitee.io/t/helm-chart-apim3-issues/311/10 and thought I'd add this in.

**Issue**

https://github.com/gravitee-io/issues/issues/8957

**Description**

-  `ui-configmap`: adjusted so BaseURL option pulls from the values file whether to use HTTP or HTTPS
- `portal-configmap`: adjusted so BaseURL option pulls from the values file whether to use HTTP or HTTPS
- `readme.adoc`: Added documentation for the UI but couldn't find where the portal section was so didn't add docs for that one