### PR TITLE
chore: Update codeowners to define devops as admin instead of techops

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default
-*                   @gravitee-io/techops @gravitee-io/archi
+*                   @gravitee-io/devops @gravitee-io/archi
 
 /ae                 @gravitee-io/ae
 /am                 @gravitee-io/am


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
