### PR TITLE
fix: add hook-delete-policy

### DIFF
--- a/am/CHANGELOG.md
+++ b/am/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to [Gravitee.io Access Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/am/) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 1.0.57
+
+- [X] Add hook-delete-policy
+
 ### 1.0.56
 
 - [X] Add `externalTrafficPolicy` in service configuration

--- a/am/Chart.yaml
+++ b/am/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: am
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 1.0.56
+version: 1.0.57
 appVersion: 3.20.1
 description: Official Gravitee.io Helm chart for Access Management
 home: https://gravitee.io
@@ -23,4 +23,4 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/am?modal=changelog
   artifacthub.io/changes: |
-    - Add `externalTrafficPolicy` in service configuration
+    - Add hook-delete-policy

--- a/am/templates/api/api-upgrader-job.yaml
+++ b/am/templates/api/api-upgrader-job.yaml
@@ -23,7 +23,7 @@ metadata:
     {{- end }}
   annotations:
     "helm.sh/hook": pre-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     {{- if .Values.api.deployment.annotations}}
     {{- range $key, $value := .Values.api.deployment.annotations }}
     {{ $key }}: {{ $value | quote }}

--- a/apim/3.x/CHANGELOG.md
+++ b/apim/3.x/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 3.1.67
+
+- [X] Add hook-delete-policy
+
 ### 3.1.65
 
 - [X] Add check to allow automatic Redis plugin download only for versions prior to 3.21.0 (it is now embedded in the distribution)

--- a/apim/3.x/Chart.yaml
+++ b/apim/3.x/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: apim3
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 3.1.65
+version: 3.1.67
 appVersion: 3.20.1
 description: Official Gravitee.io Helm chart for API Management 3.x
 home: https://gravitee.io
@@ -20,4 +20,4 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/apim3?modal=changelog
   artifacthub.io/changes: |
-    - Add `gracefulShutdown` in gateway configuration
+    - Add hook-delete-policy

--- a/apim/3.x/templates/api/api-upgrader-job.yaml
+++ b/apim/3.x/templates/api/api-upgrader-job.yaml
@@ -23,7 +23,7 @@ metadata:
     {{- end }}
   annotations:
     "helm.sh/hook": pre-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     {{- if .Values.api.deployment.annotations}}
     {{- range $key, $value := .Values.api.deployment.annotations }}
     {{ $key }}: {{ $value | quote }}

--- a/apim/3.x/tests/api/api_upgrader_test.yaml
+++ b/apim/3.x/tests/api/api_upgrader_test.yaml
@@ -46,13 +46,13 @@ tests:
           path: metadata.annotations
           value:
             helm.sh/hook: pre-upgrade
-            helm.sh/hook-delete-policy: hook-succeeded
+            helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
       - equal:
           path: metadata.annotations.[helm.sh/hook]
           value: pre-upgrade
       - equal:
           path: metadata.annotations.[helm.sh/hook-delete-policy]
-          value: hook-succeeded
+          value: before-hook-creation,hook-succeeded
 
   - it: Check if the upgrader manifest is disabled by default
     template: api/api-upgrader-job.yaml

--- a/cockpit/CHANGELOG.md
+++ b/cockpit/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to [Gravitee.io Cockpit](https://github.com/gravitee-io/helm-charts/tree/master/cockpit) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 1.7.5
+
+- [X] Add hook-delete-policy
+
 ### 1.7.4
 
 - [X] Make upgrader framework optional

--- a/cockpit/Chart.yaml
+++ b/cockpit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: cockpit
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 1.7.4
+version: 1.7.5
 appVersion: 3.16.0
 description: Official Gravitee.io Helm chart for Cockpit
 home: https://gravitee.io
@@ -21,5 +21,4 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/cockpit?modal=changelog
   artifacthub.io/changes: |
-    - Make upgrader framework optional
-    - Add `externalTrafficPolicy` in service configuration
+    - Add hook-delete-policy

--- a/cockpit/templates/api/api-upgrader-job.yaml
+++ b/cockpit/templates/api/api-upgrader-job.yaml
@@ -24,7 +24,7 @@ metadata:
     {{- end }}
   annotations:
     "helm.sh/hook": pre-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     {{- if .Values.api.deployment.annotations}}
     {{- range $key, $value := .Values.api.deployment.annotations }}
     {{ $key }}: {{ $value | quote }}

--- a/cockpit/tests/api/api_upgrader_test.yaml
+++ b/cockpit/tests/api/api_upgrader_test.yaml
@@ -46,10 +46,10 @@ tests:
           path: metadata.annotations
           value:
             helm.sh/hook: pre-upgrade
-            helm.sh/hook-delete-policy: hook-succeeded
+            helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
       - equal:
           path: metadata.annotations.[helm.sh/hook]
           value: pre-upgrade
       - equal:
           path: metadata.annotations.[helm.sh/hook-delete-policy]
-          value: hook-succeeded
+          value: before-hook-creation,hook-succeeded


### PR DESCRIPTION
This small fix is just trying to remove the upgrader job before running any new one. This is needed to automatically remove failled jobs in the case that there was an error during the upgrade.
If there was no error during the upgrade, the job will be removed automatically.