### PR TITLE
fix(apim): syntax error in gateway-configmap.yaml for Redis when Helm…

### DIFF
--- a/apim/3.x/templates/gateway/gateway-configmap.yaml
+++ b/apim/3.x/templates/gateway/gateway-configmap.yaml
@@ -179,7 +179,7 @@ data:
         {{- if .Values.gateway.ratelimit.redis.ssl }}
         ssl: {{ .Values.gateway.ratelimit.redis.ssl }}
         {{- end }}
-        {{- if and .Values.gateway.ratelimit.redis.sentinel (not (empty .Values.gateway.ratelimit.redis.sentinel.nodes)) }}
+        {{- if (not (empty ((.Values.gateway.ratelimit.redis.sentinel).nodes))) }}
         sentinel:
           master: {{ .Values.gateway.ratelimit.redis.sentinel.master }}
           nodes:


### PR DESCRIPTION
… version used prior to 3.10.x

**Issue**

https://gravitee.atlassian.net/browse/APIM-1438

**Description**

When using a version of Helm prior to 3.10, a syntax error like this happens when Sentinel is not configured for Redis client : 
`Error: UPGRADE FAILED: template: apim3/templates/gateway/gateway-deployment.yaml:56:28: executing "apim3/templates/gateway/gateway-deployment.yaml" at <include (print $.Template.BasePath "/gateway/gateway-configmap.yaml") .>: error calling include: template: apim3/templates/gateway/gateway-configmap.yaml:179:79: executing "apim3/templates/gateway/gateway-configmap.yaml" at <.Values.gateway.ratelimit.redis.sentinel.nodes>: nil pointer evaluating interface {}.nodes`

The problem comes from the fact that the `and` operator evaluate all argument even if the first is falsey in Go version prior to 1.18. This has been fixed in version 1.18 which is version use in Helm from 3.10 version.

To avoid the issue, there are two options : 

- Bump your Helm version to at least 3.10
- Add the **sentinel** line in your values.yaml file in the Redis section : 
`
  ratelimit:
    redis:
      host: redis-host
      port: 6379
      password: secret
      sentinel: {}
`

