### PR TITLE
add labels to cm, secrets, ingress and service

### DIFF
--- a/ae/templates/engine-configmap.yaml
+++ b/ae/templates/engine-configmap.yaml
@@ -10,6 +10,9 @@ metadata:
     app.kubernetes.io/component: "{{ .Values.engine.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    {{- range $key, $value := .Values.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 data:
   gravitee.yml: |
     ingesters:

--- a/ae/templates/engine-ingress.yaml
+++ b/ae/templates/engine-ingress.yaml
@@ -15,6 +15,9 @@ metadata:
     app.kubernetes.io/component: "{{ .Values.engine.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    {{- range $key, $value := .Values.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
   annotations:
     {{- if .Values.engine.ingress.annotations }}
     {{- include "common.ingress.annotations.render" (dict "annotations" .Values.engine.ingress.annotations "ingressClassName" .Values.engine.ingress.ingressClassName "context" $) | nindent 4 }}

--- a/ae/templates/engine-service.yaml
+++ b/ae/templates/engine-service.yaml
@@ -10,6 +10,9 @@ metadata:
     app.kubernetes.io/component: "{{ .Values.engine.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    {{- range $key, $value := .Values.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
   annotations:
     {{- range $key, $value := .Values.engine.service.annotations }}
       {{ $key }}: {{ $value | quote }}

--- a/ae/templates/licenses-secrets.yaml
+++ b/ae/templates/licenses-secrets.yaml
@@ -5,6 +5,12 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .name }}
+  {{- if $.Values.labels }}
+  labels:
+    {{- range $key, $value := $.Values.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 type: Opaque
 data:
   licensekey: {{ .key }}


### PR DESCRIPTION
Deployment uses .Values.labels as default value to engine.deployment.labels
This PR proposes to add those labels to cm, secrets, ingress and service objects