### PR TITLE
fix(cockpit): on notifiers configuration, allow TLS without custom keystore

### DIFF
--- a/cockpit/CHANGELOG.md
+++ b/cockpit/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to [Gravitee.io Cockpit](https://github.com/gravitee-io/helm-charts/tree/master/cockpit) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 1.8.1
+
+- [X] Email notifier fix configuration with TLS without truststore
+
 ### 1.8.0
 
 - [X] Email notifier definition added

--- a/cockpit/Chart.yaml
+++ b/cockpit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: cockpit
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 1.8.0
+version: 1.8.1
 appVersion: 3.16.0
 description: Official Gravitee.io Helm chart for Cockpit
 home: https://gravitee.io

--- a/cockpit/templates/api/api-configmap.yaml
+++ b/cockpit/templates/api/api-configmap.yaml
@@ -167,12 +167,18 @@ data:
         subject: {{ .email.subject | quote }}
         password: {{ .email.password }}
         from: cloud@graviteesource.com
-        {{- if .email.startTLSEnabled }}
+      {{- if .email.startTLSEnabled }}
         startTLSEnabled: true
+        {{- if hasKey .email "sslKeyStore" }}
         sslKeyStore: {{ .email.sslKeyStore }}
+        {{- end }}
+        {{- if hasKey .email "sslTrustAll" }}
         sslTrustAll: {{ .email.sslTrustAll }}
+        {{- end }}
+        {{- if hasKey .email "sslKeyStorePassword" }}
         sslKeyStorePassword: {{ .email.sslKeyStorePassword }}
         {{- end }}
+      {{- end }}
   {{- end }}
   {{- end }}
 

--- a/cockpit/tests/api/api-configmap_gravitee_yaml_test.yaml
+++ b/cockpit/tests/api/api-configmap_gravitee_yaml_test.yaml
@@ -1265,3 +1265,169 @@ tests:
                 responseType: code
                 scopes: openid,profile,email
 
+
+  - it: should enable notifiers when TLS enabled without truststore
+    template: api/api-configmap.yaml
+    set:
+      notifiers:
+        enabled: true
+        tryAvoidDuplicateNotification: true
+        email:
+          host: my.host.name
+          port: 445
+          username: cockpit
+          subject: awesome test
+          password: strong password
+          from: cloud@graviteesource.com
+          startTLSEnabled: true
+    release:
+      name: my-cockpit
+      namespace: unittest
+    chart:
+      version: 1.0.0-chart
+      appVersion: 1.0.0-app
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data.[gravitee.yml]
+          value: |
+            jetty:
+              port: 8063
+            
+            management:
+              type: mongodb
+              mongodb:
+                sslEnabled: false
+                socketKeepAlive: false
+                uri: mongodb://graviteeio-cockpit-mongodb-replicaset-headless:27017/gravitee?&replicaSet=rs0&connectTimeoutMS=30000
+            swaggerGenerator:
+              url: http://my-cockpit-swagger-generator:84
+              apiKey: api_key_value
+            
+            services:
+              notifier:
+                enabled: true
+                tryAvoidDuplicateNotification: true
+              core:
+                http:
+                  enabled: true
+                  port: 18063
+                  host: localhost
+                  authentication:
+                    type: basic
+                    users:
+                      admin: adminadmin
+              healthCheckPurge:
+                cron: 0 0 0 */1 * *
+                onPremise:
+                  dataRetentionDuration: -1
+            
+            reCaptcha:
+              enabled: false
+            
+            controller:
+              compatible-versions:
+                am: 3.7.0
+                apim: 3.6.2
+                connector: 1.2.0
+            
+            email:
+              enabled: true
+              host: smtp.example.com
+              subject: "[gravitee] %s"
+              port: 25
+              from: info@example.com
+              username: info@example.com
+              password: example.com
+              properties:
+                auth : "true"
+                starttls.enable : "false"
+            
+            notifiers:
+              email:
+                host: my.host.name
+                port: 445
+                username: cockpit
+                subject: "awesome test"
+                password: strong password
+                from: cloud@graviteesource.com
+                startTLSEnabled: true
+            
+            jwt:
+              secret: ybbrZDZmjnzWhstP8xv2SQL28AdHuNah
+            
+            platform:
+              admin:
+                password: $2a$10$YCR.gYLmG8TzKSg5TYxdzeJOpMGpEavOCni5sbHukD2qwwZxhuXvO
+            
+            certificates:
+              secret: QdjshTRmurH3YtzFCrYATkSG8H65xwah
+              principal: 'EMAILADDRESS=contact@graviteesource.com, CN={accountId}, OU=Cockpit, O=GraviteeSource, L=Lille, ST=France, C=FR'
+              expire-after: 31536000
+              key:
+                alg: RSA
+                size: 4096
+              signature:
+                alg: SHA512WithRSA
+            
+            endpoints:
+              loginPath: "/auth/cockpit?token={token}"
+              apim:
+                name: "GraviteeAPIManagement"
+                ui: "http://localhost:3000"
+                api: "http://localhost:8083/management"
+              am:
+                name: "GraviteeAccessManagement"
+                ui: "http://localhost:4200"
+                api: "http://localhost:8093/management"
+              ui: "https://cockpit.example.com/"
+              ws: "https://cockpit-controller.example.com/"
+            initialPlans:
+              large:
+                dataRetentionDuration: 182
+                maxDesignerModelsCount: 1
+                maxEnvs: -1
+                name: Large
+              medium:
+                dataRetentionDuration: 30
+                maxDesignerModelsCount: 1
+                maxEnvs: 4
+                name: Medium
+              small:
+                dataRetentionDuration: 1
+                isDefault: "true"
+                maxDesignerModelsCount: 1
+                maxEnvs: 2
+                name: Small
+            
+            auth:
+              callbackUrl: /management/auth/login/callback
+              github:
+                redirectUri: https://cockpit.example.com/management/auth/login/callback?provider=github
+                accessTokenUri: https://github.com/login/oauth/access_token
+                clientId: null
+                clientSecret: null
+                codeParameter: code
+                responseType: code
+                userAutorizationUri: https://github.com/login/oauth/authorize
+                userProfileUri: https://api.github.com/user
+              google:
+                redirectUri: https://cockpit.example.com/management/auth/login/callback?provider=google
+                accessTokenUri: https://oauth2.googleapis.com/token
+                clientId: null
+                clientSecret: null
+                codeParameter: code
+                responseType: code
+                scopes: openid,profile,email
+                userAutorizationUri: https://accounts.google.com/o/oauth2/v2/auth
+                userProfileUri: https://openidconnect.googleapis.com/v1/userinfo
+              oidc:
+                redirectUri: https://cockpit.example.com/management/auth/login/callback?provider=oidc
+                clientId: null
+                clientSecret: null
+                codeParameter: code
+                responseType: code
+                scopes: openid,profile,email


### PR DESCRIPTION
**Description**

Add the test: 'should enable notifiers when TLS enabled without truststore' and make it pass.
