### PR TITLE
fix: remove old cache type configuration

### DIFF
--- a/apim/3.x/CHANGELOG.md
+++ b/apim/3.x/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 3.1.67
+
+- [X] Remove old and unused `cache.type` from gateway config map
+
 ### 3.1.66
 
 - [X] Add sni to the gateway configuration

--- a/apim/3.x/Chart.yaml
+++ b/apim/3.x/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: apim3
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 3.1.66
+version: 3.1.67
 appVersion: 3.20.1
 description: Official Gravitee.io Helm chart for API Management 3.x
 home: https://gravitee.io

--- a/apim/3.x/templates/gateway/gateway-configmap.yaml
+++ b/apim/3.x/templates/gateway/gateway-configmap.yaml
@@ -190,10 +190,6 @@ data:
         {{- end }}
       {{- end }}
 
-    cache:
-      type: ehcache
-      enabled: true
-
     # Sharding tags configuration
     # Allows to define inclusion/exclusion sharding tags to only deploy a part of APIs. To exclude just prefix the tag with '!'.
     tags: {{ .Values.gateway.sharding_tags }}  


### PR DESCRIPTION
**Description**

While introducing new cache manager, a old and used cache.type configuration has been removed and is in conflict with the new mechanism. This PR just remove it from the hard coded config map.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
