### PR TITLE
feat: add labels to apim gateway configmap

### DIFF
--- a/apim/3.x/CHANGELOG.md
+++ b/apim/3.x/CHANGELOG.md
@@ -6,6 +6,7 @@ This file documents all notable changes to [Gravitee.io API Management 3.x](http
 ### 3.1.69
 
 - [X] Allow disabling analytics in Management API
+- [X] Allow labels and annotations on Gateway Config Map
 
 ### 3.1.68
 

--- a/apim/3.x/Chart.yaml
+++ b/apim/3.x/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: apim3
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 3.1.68
+version: 3.1.69
 appVersion: 3.20.1
 description: Official Gravitee.io Helm chart for API Management 3.x
 home: https://gravitee.io
@@ -20,5 +20,5 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/apim3?modal=changelog
   artifacthub.io/changes: |
-    - Revert commit 7d54c57a981fa6c4df13ce2c8604d2124b3b01c0
     - Allow disabling analytics in Management API
+    - Allow labels and annotations on Gateway Config Map

--- a/apim/3.x/templates/gateway/gateway-configmap.yaml
+++ b/apim/3.x/templates/gateway/gateway-configmap.yaml
@@ -10,6 +10,16 @@ metadata:
     app.kubernetes.io/component: "{{ .Values.gateway.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  {{- if .Values.gateway.configMap.labels}}
+    {{- range $key, $value := .Values.gateway.configMap.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.gateway.configMap.annotations}}
+    {{- range $key, $value := .Values.gateway.configMap.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 data:
   {{- if not (include "gateway.externalConfig" .)}}
   gravitee.yml: |

--- a/apim/3.x/values.yaml
+++ b/apim/3.x/values.yaml
@@ -696,6 +696,9 @@ gateway:
     jettyLevel: WARN
   # If you provide your own gravitee.yml by using a volumeMount, reloadOnConfigChange is disabled.
   reloadOnConfigChange: true
+  configMap:
+    labels: {}
+    annotations: {}
   deployment:
     # Annotations to apply to the deployment
     annotations: {}


### PR DESCRIPTION
labels are required by the Kubernetes Operator to access gateway configuration