### PR TITLE
Adding missing mongo truststore and keystore configuration 

### DIFF
--- a/apim/3.x/templates/gateway/gateway-configmap.yaml
+++ b/apim/3.x/templates/gateway/gateway-configmap.yaml
@@ -168,6 +168,14 @@ data:
         {{- else }}
         uri: mongodb://{{- if (eq .Values.mongo.auth.enabled true) }}{{ .Values.mongo.auth.username }}:{{ .Values.mongo.auth.password }}@{{- end }}{{ .Values.mongo.dbhost }}:{{ .Values.mongo.dbport }}/{{ .Values.mongo.dbname }}?{{- if .Values.mongo.rsEnabled }}&replicaSet={{ .Values.mongo.rs }}{{- end }}{{- if (eq .Values.mongo.auth.enabled true) }}&authSource={{ .Values.mongo.auth.source }}{{- end }}{{- if .Values.mongo.connectTimeoutMS }}&connectTimeoutMS={{ .Values.mongo.connectTimeoutMS }}{{- end }}
         {{- end }}
+        {{- if .Values.mongo.keystore }}
+        keystore:
+        {{- toYaml .Values.mongo.keystore | nindent 10 }}
+        {{- end }}
+        {{- if .Values.mongo.truststore }}
+        truststore:
+        {{- toYaml .Values.mongo.truststore | nindent 10 }}
+        {{- end }}
       {{- else if (eq .Values.ratelimit.type "jdbc") }}
       jdbc:
         url: {{ .Values.jdbc.url }}


### PR DESCRIPTION
**Issue**
https://github.com/gravitee-io/issues/issues/9067

**Description**

When deploying to a Mongo instance with TLS enabled the truststore configuration was missing on the ratelimit section of the Gravitee Gateway config, This PR adds this section back in to match the Management section and the API configmap management section.
