### PR TITLE
Fix indentation for api section in config map

### DIFF
--- a/apim/3.x/templates/api/api-configmap.yaml
+++ b/apim/3.x/templates/api/api-configmap.yaml
@@ -495,7 +495,7 @@ data:
     {{- end }}
     # APIs specific configuration
     {{- if .Values.api.api }}
-      api: {{- toYaml .Values.api.api | nindent 6 -}}
+    api: {{- toYaml .Values.api.api | nindent 6 -}}
     {{- end}}
     {{- end }}
     {{- if .Values.api.logging.debug }}

--- a/apim/3.x/templates/gateway/gateway-configmap.yaml
+++ b/apim/3.x/templates/gateway/gateway-configmap.yaml
@@ -419,7 +419,7 @@ data:
 
     # APIs specific configuration
     {{- if .Values.gateway.api }}
-      api: {{- toYaml .Values.gateway.api | nindent 6 -}}
+    api: {{- toYaml .Values.gateway.api | nindent 6 -}}
     {{- end}}
 
     gracefulShutdown:


### PR DESCRIPTION
**Issue**
The following configuration is not applied, due to wrong indentation: 
```
    api:
      properties:
        encryption:
          secret:
```
During the start of the application we have the following log:
```
WARN  i.gravitee.common.util.DataEncryptor - ##############################################################
WARN  i.gravitee.common.util.DataEncryptor - #                      SECURITY WARNING                      #
WARN  i.gravitee.common.util.DataEncryptor - ##############################################################
WARN  i.gravitee.common.util.DataEncryptor -
WARN  i.gravitee.common.util.DataEncryptor - You still use the default secret.
WARN  i.gravitee.common.util.DataEncryptor - This known secret can be used to access protected information.
WARN  i.gravitee.common.util.DataEncryptor - Please customize the 'api.properties.encryption.secret' parameter value, or ask your administrator to do it.
WARN  i.gravitee.common.util.DataEncryptor -
WARN  i.gravitee.common.util.DataEncryptor - ##############################################################
```

**Description**

Fixed indentation

