### PR TITLE
[FIX] #9098: [APIM] HELM Charts missing resources section for ui-deployment

### DIFF
--- a/apim/3.x/templates/ui/ui-deployment.yaml
+++ b/apim/3.x/templates/ui/ui-deployment.yaml
@@ -151,6 +151,7 @@ spec:
           {{- else if and (.Values.ui.deployment.customStartupProbe) (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
           startupProbe: {{ toYaml .Values.ui.deployment.customStartupProbe | nindent 12 }}
           {{- end }}
+          resources: {{ toYaml .Values.ui.resources | nindent 12 }}
           volumeMounts:
             - name: config
               mountPath: /usr/share/nginx/html/constants.json


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/9098

**Description**

resources section was removed in the template apim/3.x/templates/ui/ui-deployment.yaml in chart 3.2.0, present in 3.1.67

**Additional context**

resources:

https://artifacthub.io/packages/helm/graviteeio/apim3/3.20.11?modal=template&template=ui/ui-deployment.yamlhttps://artifacthub.io/packages/helm/graviteeio/apim3/3.20.11?modal=template&template=ui/ui-deployment.yaml