### PR TITLE
feat: Add podSecurityContext at deployment spec level

### DIFF
--- a/ae/Chart.yaml
+++ b/ae/Chart.yaml
@@ -20,6 +20,7 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/ae?modal=changelog
   artifacthub.io/changes: |
+    - Add podSecurityContext
     - Allow users to define their own configuration file by defining a volume
     - Add `externalTrafficPolicy` in service configuration
 

--- a/ae/templates/engine-deployment.yaml
+++ b/ae/templates/engine-deployment.yaml
@@ -71,6 +71,9 @@ spec:
         {{- end }}
         {{- end }}
     spec:
+      {{- if .Values.engine.deployment.podSecurityContext }}
+      securityContext: {{ toYaml .Values.engine.deployment.podSecurityContext | nindent 8 }}
+      {{ end }}
       {{- if $serviceAccount }}
       serviceAccountName: {{ $serviceAccount }}
       {{ end }}

--- a/ae/tests/deployment_test.yaml
+++ b/ae/tests/deployment_test.yaml
@@ -329,3 +329,19 @@ tests:
               items:
                 - key: licensekey
                   path: license.key
+
+  - it: Deploy with podSecurityContext
+    template: engine-deployment.yaml
+    set:
+      engine:
+        deployment:
+          podSecurityContext:
+            fsGroup: 1001
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1001

--- a/ae/values.yaml
+++ b/ae/values.yaml
@@ -84,6 +84,12 @@ engine:
     envFrom: []
     # - configMapRef:
     #     name: config-secret
+    # SecurityContext holds pod-level security attributes and common container settings.
+    # Field values of container.securityContext take precedence over field values of PodSecurityContext.
+    #podSecurityContext:
+      #fsGroup: 1001
+      #runAsUser: 1001
+      #runAsNonRoot: true
     securityContext:
       runAsUser: 1001
       runAsNonRoot: true

--- a/cockpit/Chart.yaml
+++ b/cockpit/Chart.yaml
@@ -21,6 +21,7 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/cockpit?modal=changelog
   artifacthub.io/changes: |
+    - Add podSecurityContext
     - Add property to override endpoints ui URL
     - Add property to override endpoints ws URL
     - Add property to override authentication callback URL

--- a/cockpit/templates/api/api-deployment.yaml
+++ b/cockpit/templates/api/api-deployment.yaml
@@ -66,6 +66,9 @@ spec:
         {{- end }}
         {{- end }}
     spec:
+      {{- if .Values.api.deployment.podSecurityContext }}
+      securityContext: {{ toYaml .Values.api.deployment.podSecurityContext | nindent 8 }}
+      {{ end }}
       {{- if $serviceAccount }}
       serviceAccountName: {{ $serviceAccount }}
       {{ end }}

--- a/cockpit/templates/generator/generator-deployment.yaml
+++ b/cockpit/templates/generator/generator-deployment.yaml
@@ -61,6 +61,9 @@ spec:
         {{- end }}
         {{- end }}
     spec:
+      {{- if .Values.generator.deployment.podSecurityContext }}
+      securityContext: {{ toYaml .Values.generator.deployment.podSecurityContext | nindent 8 }}
+      {{ end }}
       {{- if $serviceAccount }}
       serviceAccountName: {{ $serviceAccount }}
       {{ end }}

--- a/cockpit/templates/ui/ui-deployment.yaml
+++ b/cockpit/templates/ui/ui-deployment.yaml
@@ -63,6 +63,9 @@ spec:
         {{- end }}
         {{- end }}
     spec:
+      {{- if .Values.ui.deployment.podSecurityContext }}
+      securityContext: {{ toYaml .Values.ui.deployment.podSecurityContext | nindent 8 }}
+      {{- end }}
       affinity: {{- toYaml $mergedAffinity | nindent 8 }}
       nodeSelector: {{ toYaml .Values.ui.deployment.nodeSelector | nindent 8 }}
       topologySpreadConstraints: {{ toYaml .Values.ui.deployment.topologySpreadConstraints | nindent 8 }}

--- a/cockpit/tests/api/api-deployment_test.yaml
+++ b/cockpit/tests/api/api-deployment_test.yaml
@@ -256,3 +256,19 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: "test-sa"
+
+  - it: Deploy with podSecurityContext
+    template: api/api-deployment.yaml
+    set:
+      api:
+        deployment:
+          podSecurityContext:
+            fsGroup: 1001
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1001

--- a/cockpit/tests/generator/generator-deployment_test.yaml
+++ b/cockpit/tests/generator/generator-deployment_test.yaml
@@ -200,3 +200,19 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: "test-sa"
+
+  - it: Deploy with podSecurityContext
+    template: generator/generator-deployment.yaml
+    set:
+      generator:
+        deployment:
+          podSecurityContext:
+            fsGroup: 1001
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1001

--- a/cockpit/tests/ui/ui-deployment_test.yaml
+++ b/cockpit/tests/ui/ui-deployment_test.yaml
@@ -185,3 +185,19 @@ tests:
       - equal:
           path: spec.revisionHistoryLimit
           value: 10
+
+  - it: Deploy with podSecurityContext
+    template: ui/ui-deployment.yaml
+    set:
+      ui:
+        deployment:
+          podSecurityContext:
+            fsGroup: 1001
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1001

--- a/cockpit/values.yaml
+++ b/cockpit/values.yaml
@@ -332,6 +332,12 @@ api:
     internalPortName: api-http
 #    appProtocol: http
   # annotations:
+  # SecurityContext holds pod-level security attributes and common container settings.
+  # Field values of container.securityContext take precedence over field values of PodSecurityContext.
+  #podSecurityContext:
+    #fsGroup: 1001
+    #runAsUser: 1001
+    #runAsNonRoot: true
   securityContext:
     runAsUser: 1001
     runAsNonRoot: true
@@ -443,6 +449,12 @@ ui:
     envFrom: []
     # - configMapRef:
     #     name: config-secret
+    # SecurityContext holds pod-level security attributes and common container settings.
+    # Field values of container.securityContext take precedence over field values of PodSecurityContext.
+    #podSecurityContext:
+      #fsGroup: 1001
+      #runAsUser: 1001
+      #runAsNonRoot: true
     securityContext:
       runAsUser: 101
       runAsGroup: 101
@@ -595,6 +607,12 @@ generator:
     envFrom: []
     # - configMapRef:
     #     name: config-secret
+    # SecurityContext holds pod-level security attributes and common container settings.
+    # Field values of container.securityContext take precedence over field values of PodSecurityContext.
+    #podSecurityContext:
+      #fsGroup: 1001
+      #runAsUser: 1001
+      #runAsNonRoot: true
     securityContext:
       runAsUser: 1001
       runAsNonRoot: true


### PR DESCRIPTION
**Issue**

Issue [#9209](https://github.com/gravitee-io/issues/issues/9209) on APIM replicated to Cockpit and AE.
[https://gravitee.atlassian.net/browse/DEVOPS-179](DEVOPS-179)

**Description**

Add podSecurityContext at deployment spec level

In addition of the container level, you can now define a security
context at pod level.

DEVOPS-179
