### PR TITLE
feat: allow ingress host wildcard

### DIFF
--- a/ae/Chart.yaml
+++ b/ae/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: ae
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 1.1.42
+version: 1.1.43
 appVersion: 2.0.0
 description: Official Gravitee.io Helm chart for Alert Engine
 home: https://gravitee.io
@@ -20,7 +20,6 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/ae?modal=changelog
   artifacthub.io/changes: |
+    - Allow wildcard in ingress host
     - Add podSecurityContext
-    - Allow users to define their own configuration file by defining a volume
-    - Add `externalTrafficPolicy` in service configuration
 

--- a/ae/templates/engine-ingress.yaml
+++ b/ae/templates/engine-ingress.yaml
@@ -25,7 +25,7 @@ spec:
   {{- end }}
   rules:
   {{- range $host := .Values.engine.ingress.hosts }}
-  - host: {{ $host }}
+  - host: {{ $host | quote }}
     http:
       paths:
       - pathType: Prefix

--- a/ae/templates/engine-technical-ingress.yaml
+++ b/ae/templates/engine-technical-ingress.yaml
@@ -25,7 +25,7 @@ spec:
   {{- end }}
   rules:
   {{- range $host := .Values.engine.services.core.ingress.hosts }}
-  - host: {{ $host }}
+  - host: {{ $host | quote }}
     http:
       paths:
       - pathType: Prefix

--- a/ae/tests/ingress_technical_test.yaml
+++ b/ae/tests/ingress_technical_test.yaml
@@ -80,3 +80,17 @@ tests:
       - equal:
           path: spec.ingressClassName
           value: nginx
+
+  - it: Check Ingress host with wildcard
+    set:
+      engine:
+        services:
+          core:
+            ingress:
+              enabled: true
+              hosts:
+                - "*.ae.example.com"
+    asserts:
+      - equal:
+          path: spec.rules[0].host
+          value: "*.ae.example.com"

--- a/ae/tests/ingress_test.yaml
+++ b/ae/tests/ingress_test.yaml
@@ -56,3 +56,16 @@ tests:
       - equal:
           path: spec.ingressClassName
           value: nginx
+
+  - it: Check Ingress host with wildcard
+    set:
+      engine:
+        enabled: true
+        ingress:
+          enabled: true
+          hosts:
+            - "*.ae.example.com"
+    asserts:
+      - equal:
+          path: spec.rules[0].host
+          value: "*.ae.example.com"

--- a/cockpit/Chart.yaml
+++ b/cockpit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: cockpit
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 1.9.1
+version: 1.9.2
 appVersion: 3.16.0
 description: Official Gravitee.io Helm chart for Cockpit
 home: https://gravitee.io
@@ -21,7 +21,5 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/cockpit?modal=changelog
   artifacthub.io/changes: |
+    - Allow wildcard in ingress host
     - Add podSecurityContext
-    - Add property to override endpoints ui URL
-    - Add property to override endpoints ws URL
-    - Add property to override authentication callback URL

--- a/cockpit/templates/api/api-ingress-technical.yaml
+++ b/cockpit/templates/api/api-ingress-technical.yaml
@@ -25,7 +25,7 @@ spec:
   {{- end }}
   rules:
   {{- range $host := .Values.api.http.services.core.ingress.hosts }}
-  - host: {{ $host }}
+  - host: {{ $host | quote }}
     http:
       paths:
       - pathType: Prefix

--- a/cockpit/templates/api/api-ingress-ws.yaml
+++ b/cockpit/templates/api/api-ingress-ws.yaml
@@ -25,7 +25,7 @@ spec:
   {{- end }}
   rules:
   {{- range $host := .Values.api.controller.ws.ingress.hosts }}
-  - host: {{ $host }}
+  - host: {{ $host | quote }}
     http:
       paths:
       - pathType: Prefix

--- a/cockpit/templates/api/api-ingress.yaml
+++ b/cockpit/templates/api/api-ingress.yaml
@@ -25,7 +25,7 @@ spec:
   {{- end }}
   rules:
   {{- range $host := .Values.api.ingress.hosts }}
-  - host: {{ $host }}
+  - host: {{ $host | quote }}
     http:
       paths:
       - pathType: Prefix

--- a/cockpit/templates/ui/ui-ingress.yaml
+++ b/cockpit/templates/ui/ui-ingress.yaml
@@ -25,7 +25,7 @@ spec:
   {{- end }}
   rules:
   {{- range $host := .Values.ui.ingress.hosts }}
-  - host: {{ $host }}
+  - host: {{ $host | quote }}
     http:
       paths:
       - pathType: Prefix

--- a/cockpit/tests/api/api-ingress-technical_test.yaml
+++ b/cockpit/tests/api/api-ingress-technical_test.yaml
@@ -290,3 +290,20 @@ tests:
               - hosts:
                   - cockpit.example.com
                 secretName: api-custom-cert
+
+  - it: Check Ingress host with wildcard
+    set:
+      api:
+        http:
+          services:
+            core:
+              http:
+                enabled: true
+              ingress:
+                enabled: true
+                hosts:
+                  - "*.cockpit.example.com"
+    asserts:
+      - equal:
+          path: spec.rules[0].host
+          value: "*.cockpit.example.com"

--- a/cockpit/tests/api/api-ingress-ws_test.yaml
+++ b/cockpit/tests/api/api-ingress-ws_test.yaml
@@ -138,3 +138,19 @@ tests:
               - hosts:
                   - cockpit-controller.example.com
                 secretName: api-custom-cert
+
+  - it: Check Ingress host with wildcard
+    set:
+
+      api:
+        controller:
+          ws:
+            enabled: true
+            ingress:
+              enabled: true
+              hosts:
+                - "*.cockpit.example.com"
+    asserts:
+      - equal:
+          path: spec.rules[0].host
+          value: "*.cockpit.example.com"

--- a/cockpit/tests/api/api-ingress_test.yaml
+++ b/cockpit/tests/api/api-ingress_test.yaml
@@ -136,3 +136,16 @@ tests:
               - hosts:
                   - cockpit.example.com
                 secretName: api-custom-cert
+
+  - it: Check Ingress host with wildcard
+    set:
+      api:
+        enabled: true
+        ingress:
+          enabled: true
+          hosts:
+            - "*.cockpit.example.com"
+    asserts:
+      - equal:
+          path: spec.rules[0].host
+          value: "*.cockpit.example.com"


### PR DESCRIPTION
**Issue**

linked to https://gravitee.atlassian.net/browse/APIM-2736

DEVOPS-202 > DEVOPS-206 // DEVOPS-207

**Description**

Allow ingress host wildcard

Allow usage of ingress wildcard.
Without quote, the use of '*' in the ingress host cause an yaml issue

