### PR TITLE
fix(helm): license deleted after helm upgrade

### DIFF
--- a/ae/CHANGELOG.md
+++ b/ae/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to [Gravitee.io Alert Engine](https://github.com/gravitee-io/helm-charts/tree/master/ae) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 1.1.45
+
+- [x] fix: license deleted after helm upgrade
+
 ### 1.1.44
 
 - [X] Allow users to define extra manifests

--- a/ae/Chart.yaml
+++ b/ae/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: ae
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 1.1.44
+version: 1.1.45
 appVersion: 2.1.5
 description: Official Gravitee.io Helm chart for Alert Engine
 home: https://gravitee.io
@@ -20,6 +20,4 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/ae?modal=changelog
   artifacthub.io/changes: |
-    - Allow users to define extra manifests
-    - Upgrade AE version
-
+    - 'fix: license deleted after helm upgrade'

--- a/ae/templates/licenses-secrets.yaml
+++ b/ae/templates/licenses-secrets.yaml
@@ -1,4 +1,3 @@
-{{- if not (lookup "v1" "Secret" .Release.Namespace .Values.license.name) }}
 {{- with .Values.license }}
 {{- if .key }}
 apiVersion: v1
@@ -8,6 +7,5 @@ metadata:
 type: Opaque
 data:
   licensekey: {{ .key }}
-{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/ae/values.yaml
+++ b/ae/values.yaml
@@ -272,5 +272,5 @@ engine:
   # You can also define it from command line :
   # `helm install --name graviteeio-ae graviteeio/ae --set license.key=${GRAVITEESOURCE_LICENSE_B64}`
 license:
-  name: licensekey
+  name: licensekey-ae
 #  key: <put here your license.key file encoded in base64>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/DV-332

**Description**

During an helm upgrade, the secret with gravitee license created
from `values.yml` entry: `license.key` is deleted.

It seems that the lookup implies that the ressource is not re-created,
however during the helm upgrade rotation it is deleted.

The fix consist on removing this lookup and by default name the secret
with component suffix. We set this suffix to allow specific use case
with multiple gravitee component on the same namespace (eg: APIM+AE).

