### PR TITLE
fix: split hz config for cluster and cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ commands:
         steps:
             -   run:
                     name: install helm-unittest plugin
-                    command: helm plugin install https://github.com/quintush/helm-unittest --version 0.2.11
+                    command: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 0.5.1
 
     execute-tests:
         description: execute the unit tests of the folder
@@ -29,7 +29,7 @@ commands:
         steps:
             -   run:
                     name: execute the units tests in << parameters.folder >>.
-                    command: helm unittest -3 -f '<< parameters.files >>' << parameters.folder >> -t JUnit -o << parameters.output-file >>
+                    command: helm unittest -f '<< parameters.files >>' << parameters.folder >> -t JUnit -o << parameters.output-file >>
     lint:
         description: Lint the helm charts available in the folder
         parameters:
@@ -50,7 +50,7 @@ jobs:
         steps:
             - checkout
             -   helm/install-helm-client:
-                    version: v3.7.1
+                    version: v3.15.3
             - install-helm-unittest
             -   lint:
                   folder: cockpit
@@ -73,7 +73,7 @@ jobs:
         steps:
             - checkout
             -   helm/install-helm-client:
-                    version: v3.7.1
+                    version: v3.15.3
             -   lint:
                   folder: << parameters.folder >>
 

--- a/cockpit/CHANGELOG.md
+++ b/cockpit/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to [Gravitee.io Cockpit](https://github.com/gravitee-io/helm-charts/tree/master/cockpit) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 2.0.1
+
+- [X] Split hazecast configuration for cache and cluster
+
 ### 2.0.0
 
 - [X] Add new configuration for controller

--- a/cockpit/templates/api/api-configmap.yaml
+++ b/cockpit/templates/api/api-configmap.yaml
@@ -62,12 +62,12 @@ data:
     cluster:
       type: hazelcast
       hazelcast:
-        config-path: ${gravitee.home}/config/hazelcast.xml
+        config-path: ${gravitee.home}/config/hazelcast-cluster.xml
 
     cache:
       type: hazelcast
       hazelcast:
-        config-path: ${gravitee.home}/config/hazelcast.xml
+        config-path: ${gravitee.home}/config/hazelcast-cache.xml
 
     exchange:
       controller:
@@ -284,13 +284,13 @@ data:
 {{ toYaml .Values.authentication.oidc | indent 8 }}
       {{- end }}
 
-  hazelcast.xml: |-
+  hazelcast-cluster.xml: |-
     <?xml version="1.0" encoding="UTF-8"?>
     <hazelcast xmlns="http://www.hazelcast.com/schema/config"
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                xsi:schemaLocation="http://www.hazelcast.com/schema/config
                http://www.hazelcast.com/schema/config/hazelcast-config-5.3.xsd">
-        <cluster-name>graviteeio-cockpit</cluster-name>
+        <cluster-name>graviteeio-cockpit-cluster</cluster-name>
         <properties>
             <property name="hazelcast.discovery.enabled">true</property>
             <property name="hazelcast.max.wait.seconds.before.join">3</property>
@@ -299,12 +299,45 @@ data:
             <property name="hazelcast.logging.type">slf4j</property>
         </properties>
 
-        <queue name="exchange-cluster-command-*">
+        <queue name="exchange-*">
             <backup-count>0</backup-count>
             <async-backup-count>1</async-backup-count>
+            <empty-queue-ttl>300</empty-queue-ttl>
         </queue>
 
-        <map name="exchange-controller-primary-channel-candidate">
+        <cp-subsystem>
+            <cp-member-count>0</cp-member-count>
+        </cp-subsystem>
+
+        <network>
+            <port>5701</port>
+            <join>
+                <multicast enabled="false"/>
+                <tcp-ip enabled="false"/>
+                <kubernetes enabled="true">
+                    <namespace>{{ .Release.Namespace }}</namespace>
+                    <service-name>{{ template "gravitee.api.fullname" . }}-hz</service-name>
+                    <service-port>5701</service-port>
+                </kubernetes>
+            </join>
+        </network>
+    </hazelcast>
+  hazelcast-cache.xml: |-
+    <?xml version="1.0" encoding="UTF-8"?>
+    <hazelcast xmlns="http://www.hazelcast.com/schema/config"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://www.hazelcast.com/schema/config
+               http://www.hazelcast.com/schema/config/hazelcast-config-5.3.xsd">
+        <cluster-name>graviteeio-cockpit-cache</cluster-name>
+        <properties>
+            <property name="hazelcast.discovery.enabled">true</property>
+            <property name="hazelcast.max.wait.seconds.before.join">3</property>
+            <property name="hazelcast.member.list.publish.interval.seconds">5</property>
+            <property name="hazelcast.socket.client.bind.any">false</property>
+            <property name="hazelcast.logging.type">slf4j</property>
+        </properties>
+
+        <map name="exchange-*">
             <backup-count>0</backup-count>
             <async-backup-count>1</async-backup-count>
         </map>
@@ -314,12 +347,14 @@ data:
         </cp-subsystem>
 
         <network>
+            <port>5702</port>
             <join>
                 <multicast enabled="false"/>
                 <tcp-ip enabled="false"/>
                 <kubernetes enabled="true">
                     <namespace>{{ .Release.Namespace }}</namespace>
-                    <service-name>{{ template "gravitee.api.fullname" . }}</service-name>
+                    <service-name>{{ template "gravitee.api.fullname" . }}-hz</service-name>
+                    <service-port>5702</service-port>
                 </kubernetes>
             </join>
         </network>

--- a/cockpit/templates/api/api-deployment.yaml
+++ b/cockpit/templates/api/api-deployment.yaml
@@ -142,11 +142,11 @@ spec:
               mountPath: /opt/gravitee-cockpit-management-api/config/gravitee.yml
               subPath: gravitee.yml
             - name: config
-              mountPath: /opt/gravitee-cockpit-management-api/config/hazelcast.xml
-              subPath: hazelcast.xml
+              mountPath: /opt/gravitee-cockpit-management-api/config/hazelcast-cluster.xml
+              subPath: hazelcast-cluster.xml
             - name: config
-              mountPath: /opt/gravitee-cockpit-management-api/config/hazelcast.yml
-              subPath: hazelcast.yml
+              mountPath: /opt/gravitee-cockpit-management-api/config/hazelcast-cache.xml
+              subPath: hazelcast-cache.xml
             - name: config
               mountPath: /opt/gravitee-cockpit-management-api/config/logback.xml
               subPath: logback.xml

--- a/cockpit/templates/api/api-service-hz.yaml
+++ b/cockpit/templates/api/api-service-hz.yaml
@@ -1,0 +1,32 @@
+{{- if and (.Values.api.enabled) (.Values.api.controller.ws.service.enabled) -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "gravitee.api.fullname" . }}-hz
+  labels:
+    app.kubernetes.io/name: {{ template "gravitee.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Values.api.image.tag | default .Chart.AppVersion | quote }}
+    app.kubernetes.io/component: "{{ .Values.api.name }}"
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  annotations:
+    {{- range $key, $value := .Values.api.service.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  type: "ClusterIP"
+  ports:
+    - port: 5701
+      targetPort: 5701
+      protocol: TCP
+      name: {{ printf "%s-%s" (.Values.api.name | trunc 56 | trimSuffix "-") "hz-cluster" }}
+    - port: 5702
+      targetPort: 5702
+      protocol: TCP
+      name: {{ printf "%s-%s" (.Values.api.name | trunc 56 | trimSuffix "-") "hz-cache" }}
+  selector:
+    app.kubernetes.io/name: {{ template "gravitee.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "{{ .Values.api.name }}"
+{{- end -}}

--- a/cockpit/tests/api/api-configmap_gravitee_yaml_test.yaml
+++ b/cockpit/tests/api/api-configmap_gravitee_yaml_test.yaml
@@ -49,7 +49,7 @@ tests:
       - hasDocuments:
           count: 1
       - equal:
-          path: data.[gravitee.yml]
+          path: data["gravitee.yml"]
           value: |
             jetty:
               port: 8063
@@ -64,12 +64,12 @@ tests:
             cluster:
               type: hazelcast
               hazelcast:
-                config-path: ${gravitee.home}/config/hazelcast.xml
+                config-path: ${gravitee.home}/config/hazelcast-cluster.xml
             
             cache:
               type: hazelcast
               hazelcast:
-                config-path: ${gravitee.home}/config/hazelcast.xml
+                config-path: ${gravitee.home}/config/hazelcast-cache.xml
             
             exchange:
               controller:
@@ -226,7 +226,7 @@ tests:
       - hasDocuments:
           count: 1
       - equal:
-          path: data.[gravitee.yml]
+          path: data["gravitee.yml"]
           value: |
             jetty:
               port: 8063
@@ -252,12 +252,12 @@ tests:
             cluster:
               type: hazelcast
               hazelcast:
-                config-path: ${gravitee.home}/config/hazelcast.xml
+                config-path: ${gravitee.home}/config/hazelcast-cluster.xml
             
             cache:
               type: hazelcast
               hazelcast:
-                config-path: ${gravitee.home}/config/hazelcast.xml
+                config-path: ${gravitee.home}/config/hazelcast-cache.xml
             
             exchange:
               controller:
@@ -404,7 +404,7 @@ tests:
       - hasDocuments:
           count: 1
       - equal:
-          path: data.[gravitee.yml]
+          path: data["gravitee.yml"]
           value: |
             jetty:
               port: 8063
@@ -419,12 +419,12 @@ tests:
             cluster:
               type: hazelcast
               hazelcast:
-                config-path: ${gravitee.home}/config/hazelcast.xml
+                config-path: ${gravitee.home}/config/hazelcast-cluster.xml
             
             cache:
               type: hazelcast
               hazelcast:
-                config-path: ${gravitee.home}/config/hazelcast.xml
+                config-path: ${gravitee.home}/config/hazelcast-cache.xml
             
             exchange:
               controller:
@@ -578,7 +578,7 @@ tests:
       - hasDocuments:
           count: 1
       - equal:
-          path: data.[gravitee.yml]
+          path: data["gravitee.yml"]
           value: |
             jetty:
               port: 8063
@@ -593,12 +593,12 @@ tests:
             cluster:
               type: hazelcast
               hazelcast:
-                config-path: ${gravitee.home}/config/hazelcast.xml
+                config-path: ${gravitee.home}/config/hazelcast-cluster.xml
             
             cache:
               type: hazelcast
               hazelcast:
-                config-path: ${gravitee.home}/config/hazelcast.xml
+                config-path: ${gravitee.home}/config/hazelcast-cache.xml
             
             exchange:
               controller:
@@ -746,7 +746,7 @@ tests:
       - hasDocuments:
           count: 1
       - equal:
-          path: data.[gravitee.yml]
+          path: data["gravitee.yml"]
           value: |
             jetty:
               port: 8063
@@ -761,12 +761,12 @@ tests:
             cluster:
               type: hazelcast
               hazelcast:
-                config-path: ${gravitee.home}/config/hazelcast.xml
+                config-path: ${gravitee.home}/config/hazelcast-cluster.xml
             
             cache:
               type: hazelcast
               hazelcast:
-                config-path: ${gravitee.home}/config/hazelcast.xml
+                config-path: ${gravitee.home}/config/hazelcast-cache.xml
             
             exchange:
               controller:
@@ -920,7 +920,7 @@ tests:
       - hasDocuments:
           count: 1
       - equal:
-          path: data.[gravitee.yml]
+          path: data["gravitee.yml"]
           value: |
             jetty:
               port: 8063
@@ -935,12 +935,12 @@ tests:
             cluster:
               type: hazelcast
               hazelcast:
-                config-path: ${gravitee.home}/config/hazelcast.xml
+                config-path: ${gravitee.home}/config/hazelcast-cluster.xml
             
             cache:
               type: hazelcast
               hazelcast:
-                config-path: ${gravitee.home}/config/hazelcast.xml
+                config-path: ${gravitee.home}/config/hazelcast-cache.xml
             
             exchange:
               controller:
@@ -1103,7 +1103,7 @@ tests:
       - isKind:
           of: ConfigMap
       - equal:
-          path: data.[gravitee.yml]
+          path: data["gravitee.yml"]
           value: |
             jetty:
               port: 8063
@@ -1118,12 +1118,12 @@ tests:
             cluster:
               type: hazelcast
               hazelcast:
-                config-path: ${gravitee.home}/config/hazelcast.xml
+                config-path: ${gravitee.home}/config/hazelcast-cluster.xml
             
             cache:
               type: hazelcast
               hazelcast:
-                config-path: ${gravitee.home}/config/hazelcast.xml
+                config-path: ${gravitee.home}/config/hazelcast-cache.xml
             
             exchange:
               controller:
@@ -1299,7 +1299,7 @@ tests:
       - isKind:
           of: ConfigMap
       - equal:
-          path: data.[gravitee.yml]
+          path: data["gravitee.yml"]
           value: |
             jetty:
               port: 8063
@@ -1314,12 +1314,12 @@ tests:
             cluster:
               type: hazelcast
               hazelcast:
-                config-path: ${gravitee.home}/config/hazelcast.xml
+                config-path: ${gravitee.home}/config/hazelcast-cluster.xml
             
             cache:
               type: hazelcast
               hazelcast:
-                config-path: ${gravitee.home}/config/hazelcast.xml
+                config-path: ${gravitee.home}/config/hazelcast-cache.xml
             
             exchange:
               controller:
@@ -1495,7 +1495,7 @@ tests:
       - isKind:
           of: ConfigMap
       - equal:
-          path: data.[gravitee.yml]
+          path: data["gravitee.yml"]
           value: |
             jetty:
               port: 8063
@@ -1510,12 +1510,12 @@ tests:
             cluster:
               type: hazelcast
               hazelcast:
-                config-path: ${gravitee.home}/config/hazelcast.xml
+                config-path: ${gravitee.home}/config/hazelcast-cluster.xml
             
             cache:
               type: hazelcast
               hazelcast:
-                config-path: ${gravitee.home}/config/hazelcast.xml
+                config-path: ${gravitee.home}/config/hazelcast-cache.xml
             
             exchange:
               controller:
@@ -1679,7 +1679,7 @@ tests:
       - isKind:
           of: ConfigMap
       - equal:
-          path: data.[gravitee.yml]
+          path: data["gravitee.yml"]
           value: |
             jetty:
               port: 8063
@@ -1694,12 +1694,12 @@ tests:
             cluster:
               type: hazelcast
               hazelcast:
-                config-path: ${gravitee.home}/config/hazelcast.xml
+                config-path: ${gravitee.home}/config/hazelcast-cluster.xml
             
             cache:
               type: hazelcast
               hazelcast:
-                config-path: ${gravitee.home}/config/hazelcast.xml
+                config-path: ${gravitee.home}/config/hazelcast-cache.xml
             
             exchange:
               controller:
@@ -1855,7 +1855,7 @@ tests:
       - isKind:
           of: ConfigMap
       - equal:
-          path: data.[gravitee.yml]
+          path: data["gravitee.yml"]
           value: |
             jetty:
               port: 8063
@@ -1870,12 +1870,12 @@ tests:
             cluster:
               type: hazelcast
               hazelcast:
-                config-path: ${gravitee.home}/config/hazelcast.xml
+                config-path: ${gravitee.home}/config/hazelcast-cluster.xml
             
             cache:
               type: hazelcast
               hazelcast:
-                config-path: ${gravitee.home}/config/hazelcast.xml
+                config-path: ${gravitee.home}/config/hazelcast-cache.xml
             
             exchange:
               controller:
@@ -2035,8 +2035,8 @@ tests:
       - isKind:
           of: ConfigMap
       - equal:
-          path: data.[gravitee.yml]
-          value: | 
+          path: data["gravitee.yml"]
+          value: |
             jetty:
               port: 8063
             
@@ -2050,12 +2050,12 @@ tests:
             cluster:
               type: hazelcast
               hazelcast:
-                config-path: ${gravitee.home}/config/hazelcast.xml
+                config-path: ${gravitee.home}/config/hazelcast-cluster.xml
             
             cache:
               type: hazelcast
               hazelcast:
-                config-path: ${gravitee.home}/config/hazelcast.xml
+                config-path: ${gravitee.home}/config/hazelcast-cache.xml
             
             exchange:
               controller:
@@ -2210,7 +2210,7 @@ tests:
       - isKind:
           of: ConfigMap
       - equal:
-          path: data.[gravitee.yml]
+          path: data["gravitee.yml"]
           value: |
             jetty:
               port: 8063
@@ -2225,12 +2225,12 @@ tests:
             cluster:
               type: hazelcast
               hazelcast:
-                config-path: ${gravitee.home}/config/hazelcast.xml
+                config-path: ${gravitee.home}/config/hazelcast-cluster.xml
             
             cache:
               type: hazelcast
               hazelcast:
-                config-path: ${gravitee.home}/config/hazelcast.xml
+                config-path: ${gravitee.home}/config/hazelcast-cache.xml
             
             exchange:
               controller:

--- a/cockpit/tests/api/api-configmap_hazelcast_yaml_test.yaml
+++ b/cockpit/tests/api/api-configmap_hazelcast_yaml_test.yaml
@@ -49,14 +49,14 @@ tests:
       - hasDocuments:
           count: 1
       - equal:
-          path: data.[hazelcast.xml]
-          value: |
+          path: data["hazelcast-cluster.xml"]
+          value: |-
             <?xml version="1.0" encoding="UTF-8"?>
             <hazelcast xmlns="http://www.hazelcast.com/schema/config"
                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                        xsi:schemaLocation="http://www.hazelcast.com/schema/config
                        http://www.hazelcast.com/schema/config/hazelcast-config-5.3.xsd">
-                <cluster-name>graviteeio-cockpit</cluster-name>
+                <cluster-name>graviteeio-cockpit-cluster</cluster-name>
                 <properties>
                     <property name="hazelcast.discovery.enabled">true</property>
                     <property name="hazelcast.max.wait.seconds.before.join">3</property>
@@ -65,12 +65,47 @@ tests:
                     <property name="hazelcast.logging.type">slf4j</property>
                 </properties>
 
-                <queue name="exchange-cluster-command-*">
+                <queue name="exchange-*">
                     <backup-count>0</backup-count>
                     <async-backup-count>1</async-backup-count>
+                    <empty-queue-ttl>300</empty-queue-ttl>
                 </queue>
 
-                <map name="exchange-controller-primary-channel-candidate">
+                <cp-subsystem>
+                    <cp-member-count>0</cp-member-count>
+                </cp-subsystem>
+
+                <network>
+                    <port>5701</port>
+                    <join>
+                        <multicast enabled="false"/>
+                        <tcp-ip enabled="false"/>
+                        <kubernetes enabled="true">
+                            <namespace>unittest</namespace>
+                            <service-name>my-cockpit-api-hz</service-name>
+                            <service-port>5701</service-port>
+                        </kubernetes>
+                    </join>
+                </network>
+            </hazelcast>
+      - equal:
+          path: data["hazelcast-cache.xml"]
+          value: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <hazelcast xmlns="http://www.hazelcast.com/schema/config"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xsi:schemaLocation="http://www.hazelcast.com/schema/config
+                       http://www.hazelcast.com/schema/config/hazelcast-config-5.3.xsd">
+                <cluster-name>graviteeio-cockpit-cache</cluster-name>
+                <properties>
+                    <property name="hazelcast.discovery.enabled">true</property>
+                    <property name="hazelcast.max.wait.seconds.before.join">3</property>
+                    <property name="hazelcast.member.list.publish.interval.seconds">5</property>
+                    <property name="hazelcast.socket.client.bind.any">false</property>
+                    <property name="hazelcast.logging.type">slf4j</property>
+                </properties>
+
+                <map name="exchange-*">
                     <backup-count>0</backup-count>
                     <async-backup-count>1</async-backup-count>
                 </map>
@@ -80,12 +115,14 @@ tests:
                 </cp-subsystem>
 
                 <network>
+                    <port>5702</port>
                     <join>
                         <multicast enabled="false"/>
                         <tcp-ip enabled="false"/>
                         <kubernetes enabled="true">
                             <namespace>unittest</namespace>
-                            <service-name>my-cockpit-api</service-name>
+                            <service-name>my-cockpit-api-hz</service-name>
+                            <service-port>5702</service-port>
                         </kubernetes>
                     </join>
                 </network>

--- a/cockpit/tests/api/api-configmap_logback_yaml_test.yaml
+++ b/cockpit/tests/api/api-configmap_logback_yaml_test.yaml
@@ -14,7 +14,7 @@ tests:
       - hasDocuments:
           count: 1
       - equal:
-          path: data.[logback.xml]
+          path: data["logback.xml"]
           value: |-
             <?xml version="1.0" encoding="UTF-8"?>
             <!--
@@ -68,7 +68,7 @@ tests:
       - hasDocuments:
           count: 1
       - equal:
-          path: data.[logback.xml]
+          path: data["logback.xml"]
           value: |-
             <?xml version="1.0" encoding="UTF-8"?>
             <!--

--- a/cockpit/tests/api/api-deployment_test.yaml
+++ b/cockpit/tests/api/api-deployment_test.yaml
@@ -51,8 +51,6 @@ tests:
           count: 1
       - isKind:
           of: Deployment
-      - isEmpty:
-          path: metadata.annotations
       - equal:
           path: spec.strategy
           value:
@@ -71,7 +69,7 @@ tests:
           value:
             annotations:
               chaos.alpha.kubernetes.io/enabled: "false"
-              checksum/config: 66720a55c0a46f60e4d7f7523a2673d931f895ae222fcadf80a75a18654fbe37
+              checksum/config: ac8adec57d109ab1c3903bb19c5df4227cda3f9828bf4edae4947b4efcaf36eb
             labels:
               app.kubernetes.io/component: api
               app.kubernetes.io/instance: my-cockpit
@@ -135,12 +133,12 @@ tests:
               - mountPath: /opt/gravitee-cockpit-management-api/config/gravitee.yml
                 name: config
                 subPath: gravitee.yml
-              - mountPath: /opt/gravitee-cockpit-management-api/config/hazelcast.xml
+              - mountPath: /opt/gravitee-cockpit-management-api/config/hazelcast-cluster.xml
                 name: config
-                subPath: hazelcast.xml
-              - mountPath: /opt/gravitee-cockpit-management-api/config/hazelcast.yml
+                subPath: hazelcast-cluster.xml
+              - mountPath: /opt/gravitee-cockpit-management-api/config/hazelcast-cache.xml
                 name: config
-                subPath: hazelcast.yml
+                subPath: hazelcast-cache.xml
               - mountPath: /opt/gravitee-cockpit-management-api/config/logback.xml
                 name: config
                 subPath: logback.xml
@@ -238,9 +236,8 @@ tests:
           count: 1
       - isKind:
           of: Deployment
-      - equal:
+      - isNull:
           path: spec.template.spec.serviceAccountName
-          value: null
 
   - it: Deploy with managed custom ServiceAccount
     template: api/api-deployment.yaml

--- a/cockpit/tests/api/api-ingress-technical_test.yaml
+++ b/cockpit/tests/api/api-ingress-technical_test.yaml
@@ -58,7 +58,7 @@ tests:
           of: Ingress
       - isAPIVersion:
           of: extensions/v1beta1
-      - isEmpty:
+      - isNull:
           path: spec.ingressClassName
 
   - it: Check technical Ingress networking.k8s.io/v1beta1
@@ -81,7 +81,7 @@ tests:
           of: Ingress
       - isAPIVersion:
           of: networking.k8s.io/v1beta1
-      - isEmpty:
+      - isNull:
           path: spec.ingressClassName
 
   - it: Check technical Ingress networking.k8s.io/v1 without IngressClassName
@@ -102,7 +102,7 @@ tests:
           of: Ingress
       - isAPIVersion:
           of: networking.k8s.io/v1
-      - isEmpty:
+      - isNull:
           path: spec.ingressClassName
 
   - it: Check technical Ingress networking.k8s.io/v1 with IngressClassName

--- a/cockpit/tests/api/api-pdb_test.yaml
+++ b/cockpit/tests/api/api-pdb_test.yaml
@@ -43,5 +43,5 @@ tests:
       - equal:
           path: spec.maxUnavailable
           value: 50%
-      - isEmpty:
+      - isNull:
           path: spec.minAvailable

--- a/cockpit/tests/api/api_upgrader_test.yaml
+++ b/cockpit/tests/api/api_upgrader_test.yaml
@@ -26,7 +26,7 @@ tests:
           value:
             - name: upgrade.mode
               value: "true"
-      - isEmpty:
+      - isNull:
           # It should not contain init containers by default
           path: spec.template.spec.initContainers
 
@@ -48,8 +48,8 @@ tests:
             helm.sh/hook: pre-upgrade
             helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
       - equal:
-          path: metadata.annotations.[helm.sh/hook]
+          path: metadata.annotations["helm.sh/hook"]
           value: pre-upgrade
       - equal:
-          path: metadata.annotations.[helm.sh/hook-delete-policy]
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
           value: before-hook-creation,hook-succeeded

--- a/cockpit/tests/extra-manifests_test.yaml
+++ b/cockpit/tests/extra-manifests_test.yaml
@@ -31,5 +31,5 @@ tests:
           path: metadata.name
           value: gravitee-license
       - equal:
-          path: data.license\.key
+          path: data["license.key"]
           value: myLicenceInBase64==

--- a/cockpit/tests/generator/generator-configmap_test.yaml
+++ b/cockpit/tests/generator/generator-configmap_test.yaml
@@ -49,17 +49,17 @@ tests:
       - hasDocuments:
           count: 1
       - matchRegex:
-          path: data.[env.props]
+          path: data["env.props"]
           pattern: "HOST=0.0.0.0"
       - matchRegex:
-          path: data.[env.props]
+          path: data["env.props"]
           pattern: "PORT=3003"
       - matchRegex:
-          path: data.[env.props]
+          path: data["env.props"]
           pattern: "APIZR_API_KEY_VALUE=api_key_value"
       - matchRegex:
-          path: data.[env.props]
+          path: data["env.props"]
           pattern: "LICENSE_KEY=license_value"
       - matchRegex:
-          path: data.[env.props]
+          path: data["env.props"]
           pattern: "LICENSE_EXPIRATION=license_expiration_date"

--- a/cockpit/tests/generator/generator-deployment_test.yaml
+++ b/cockpit/tests/generator/generator-deployment_test.yaml
@@ -51,8 +51,6 @@ tests:
           count: 1
       - isKind:
           of: Deployment
-      - isEmpty:
-          path: metadata.annotations
       - equal:
           path: spec.strategy
           value:
@@ -182,9 +180,8 @@ tests:
           count: 1
       - isKind:
           of: Deployment
-      - equal:
+      - isNull:
           path: spec.template.spec.serviceAccountName
-          value: null
 
   - it: Deploy with managed custom ServiceAccount
     template: generator/generator-deployment.yaml

--- a/cockpit/tests/generator/generator-pdb_test.yaml
+++ b/cockpit/tests/generator/generator-pdb_test.yaml
@@ -43,5 +43,5 @@ tests:
       - equal:
           path: spec.maxUnavailable
           value: 50%
-      - isEmpty:
+      - isNull:
           path: spec.minAvailable

--- a/cockpit/tests/ui/ui-configmap_test.yaml
+++ b/cockpit/tests/ui/ui-configmap_test.yaml
@@ -58,8 +58,8 @@ tests:
           path: data.gzip-types
           value: "*"
       - matchRegex:
-          path: data.[config.json]
+          path: data["config.json"]
           pattern: "\"baseURL\": \"https://cockpit.example.com/management\""
       - matchRegex:
-          path: data.[config.json]
+          path: data["config.json"]
           pattern: "\"loaderURL\": \"assets/images/gravitee-loader.gif\""

--- a/cockpit/tests/ui/ui-deployment_test.yaml
+++ b/cockpit/tests/ui/ui-deployment_test.yaml
@@ -51,8 +51,6 @@ tests:
           count: 1
       - isKind:
           of: Deployment
-      - isEmpty:
-          path: metadata.annotations
       - equal:
           path: spec.strategy
           value:

--- a/cockpit/tests/ui/ui-ingress_test.yaml
+++ b/cockpit/tests/ui/ui-ingress_test.yaml
@@ -25,7 +25,7 @@ tests:
           of: Ingress
       - isAPIVersion:
           of: extensions/v1beta1
-      - isEmpty:
+      - isNull:
           path: spec.ingressClassName
 
   - it: Check Ingress networking.k8s.io/v1beta1
@@ -44,12 +44,12 @@ tests:
           of: Ingress
       - isAPIVersion:
           of: networking.k8s.io/v1beta1
-      - isEmpty:
+      - isNull:
           path: spec.ingressClassName
       - isNotEmpty:
-          path: metadata.annotations.[kubernetes.io/ingress.class]
+          path: metadata.annotations["kubernetes.io/ingress.class"]
       - isNotEmpty:
-          path: metadata.annotations.[my-annotation]
+          path: metadata.annotations["my-annotation"]
 
   - it: Check Ingress networking.k8s.io/v1 without IngressClassName
     set:
@@ -65,12 +65,12 @@ tests:
           of: Ingress
       - isAPIVersion:
           of: networking.k8s.io/v1
-      - isEmpty:
+      - isNull:
           path: spec.ingressClassName
       - isNotEmpty:
-          path: metadata.annotations.[kubernetes.io/ingress.class]
+          path: metadata.annotations["kubernetes.io/ingress.class"]
       - isNotEmpty:
-          path: metadata.annotations.[my-annotation]
+          path: metadata.annotations["my-annotation"]
 
   - it: Check Ingress networking.k8s.io/v1 with IngressClassName
     set:
@@ -87,10 +87,10 @@ tests:
           of: Ingress
       - isAPIVersion:
           of: networking.k8s.io/v1
-      - isEmpty:
-          path: metadata.annotations.[kubernetes.io/ingress.class]
+      - isNull:
+          path: metadata.annotations["kubernetes.io/ingress.class"]
       - isNotEmpty:
-          path: metadata.annotations.[my-annotation]
+          path: metadata.annotations["my-annotation"]
 
   - it: should generate nothing when ingress is disabled
     template: ui/ui-ingress.yaml

--- a/cockpit/tests/ui/ui-pdb_test.yaml
+++ b/cockpit/tests/ui/ui-pdb_test.yaml
@@ -43,5 +43,5 @@ tests:
       - equal:
           path: spec.maxUnavailable
           value: 50%
-      - isEmpty:
+      - isNull:
           path: spec.minAvailable


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-391

**Description**

This fixes issues for Cockpit when running on Kubernetes. 2 Hazelcast clusters, one for cache and one for gravitee clustering, were created on the same port and caused Hz discovery issues leading to cache inconsistencies and failures when connecting APIM or AM installations to Cockpit.