### PR TITLE
fix: colon is forbidden character and cannot be used in changelog

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -904,7 +904,7 @@ entries:
   - annotations:
       artifacthub.io/changes: |2
 
-        - BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect
+        - 'BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect'
     apiVersion: v1
     appVersion: 4.4.4
     created: "2024-08-23T08:20:58.650842149Z"
@@ -937,7 +937,7 @@ entries:
   - annotations:
       artifacthub.io/changes: |2
 
-        - BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect
+        - 'BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect'
     apiVersion: v1
     appVersion: 4.4.3
     created: "2024-08-23T08:20:58.634858661Z"
@@ -970,7 +970,7 @@ entries:
   - annotations:
       artifacthub.io/changes: |2
 
-        - BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect
+        - 'BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect'
     apiVersion: v1
     appVersion: 4.4.2
     created: "2024-08-23T08:20:58.622604989Z"
@@ -1003,7 +1003,7 @@ entries:
   - annotations:
       artifacthub.io/changes: |2
 
-        - BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect
+        - 'BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect'
     apiVersion: v1
     appVersion: 4.4.1
     created: "2024-08-23T08:20:58.610399005Z"
@@ -1036,7 +1036,7 @@ entries:
   - annotations:
       artifacthub.io/changes: |2
 
-        - BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect
+        - 'BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect'
     apiVersion: v1
     appVersion: 4.4.0
     created: "2024-08-23T08:20:58.600184617Z"
@@ -1105,7 +1105,7 @@ entries:
     version: 4.4.0-alpha.1
   - annotations:
       artifacthub.io/changes: |
-        - BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect
+        - 'BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect'
     apiVersion: v1
     appVersion: 4.3.11
     created: "2024-08-23T08:20:58.460732307Z"
@@ -1137,7 +1137,7 @@ entries:
     version: 4.3.11
   - annotations:
       artifacthub.io/changes: |
-        - BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect
+        - 'BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect'
     apiVersion: v1
     appVersion: 4.3.10
     created: "2024-08-23T08:20:58.448384132Z"
@@ -1169,7 +1169,7 @@ entries:
     version: 4.3.10
   - annotations:
       artifacthub.io/changes: |
-        - BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect
+        - 'BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect'
     apiVersion: v1
     appVersion: 4.3.9
     created: "2024-08-23T08:20:58.569427125Z"
@@ -1201,7 +1201,7 @@ entries:
     version: 4.3.9
   - annotations:
       artifacthub.io/changes: |
-        - BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect
+        - 'BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect'
     apiVersion: v1
     appVersion: 4.3.8
     created: "2024-08-23T08:20:58.558900718Z"
@@ -1233,7 +1233,7 @@ entries:
     version: 4.3.8
   - annotations:
       artifacthub.io/changes: |
-        - BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect
+        - 'BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect'
     apiVersion: v1
     appVersion: 4.3.7
     created: "2024-08-23T08:20:58.546615255Z"
@@ -1524,7 +1524,7 @@ entries:
     version: 4.3.0
   - annotations:
       artifacthub.io/changes: |
-        - BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect
+        - 'BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect'
     apiVersion: v1
     appVersion: 4.2.19
     created: "2024-08-23T08:20:58.293886525Z"
@@ -1556,7 +1556,7 @@ entries:
     version: 4.2.19
   - annotations:
       artifacthub.io/changes: |
-        - BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect
+        - 'BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect'
     apiVersion: v1
     appVersion: 4.2.18
     created: "2024-08-23T08:20:58.277372767Z"
@@ -1588,7 +1588,7 @@ entries:
     version: 4.2.18
   - annotations:
       artifacthub.io/changes: |
-        - BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect
+        - 'BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect'
     apiVersion: v1
     appVersion: 4.2.17
     created: "2024-08-23T08:20:58.259831012Z"
@@ -1620,7 +1620,7 @@ entries:
     version: 4.2.17
   - annotations:
       artifacthub.io/changes: |
-        - BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect
+        - 'BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect'
     apiVersion: v1
     appVersion: 4.2.16
     created: "2024-08-23T08:20:58.243691494Z"
@@ -1652,7 +1652,7 @@ entries:
     version: 4.2.16
   - annotations:
       artifacthub.io/changes: |
-        - BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect
+        - 'BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect'
     apiVersion: v1
     appVersion: 4.2.15
     created: "2024-08-23T08:20:58.228708385Z"
@@ -1684,7 +1684,7 @@ entries:
     version: 4.2.15
   - annotations:
       artifacthub.io/changes: |
-        - BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect
+        - 'BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect'
     apiVersion: v1
     appVersion: 4.2.14
     created: "2024-08-23T08:20:58.211562192Z"
@@ -2155,7 +2155,7 @@ entries:
     version: 4.2.0
   - annotations:
       artifacthub.io/changes: |
-        - BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect
+        - 'BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect'
     apiVersion: v1
     appVersion: 4.1.28
     created: "2024-08-23T08:20:58.033064411Z"
@@ -2187,7 +2187,7 @@ entries:
     version: 4.1.28
   - annotations:
       artifacthub.io/changes: |
-        - BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect
+        - 'BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect'
     apiVersion: v1
     appVersion: 4.1.27
     created: "2024-08-23T08:20:58.021477867Z"
@@ -2219,7 +2219,7 @@ entries:
     version: 4.1.27
   - annotations:
       artifacthub.io/changes: |
-        - BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect
+        - 'BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect'
     apiVersion: v1
     appVersion: 4.1.26
     created: "2024-08-23T08:20:58.00855597Z"
@@ -2251,7 +2251,7 @@ entries:
     version: 4.1.26
   - annotations:
       artifacthub.io/changes: |
-        - BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect
+        - 'BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect'
     apiVersion: v1
     appVersion: 4.1.25
     created: "2024-08-23T08:20:57.997834626Z"
@@ -2283,7 +2283,7 @@ entries:
     version: 4.1.25
   - annotations:
       artifacthub.io/changes: |
-        - BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect
+        - 'BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect'
     apiVersion: v1
     appVersion: 4.1.24
     created: "2024-08-23T08:20:57.984856303Z"


### PR DESCRIPTION
all Helm Charts with amended changelogs are not visible in ArtifactHub. 
According to https://gravitee.slab.com/posts/helm-chart-release-lifecycle-h7m002pk#hdbxl-concretely-what-should-i-do ":" is forbidden character and should be enclosed in quotes. 